### PR TITLE
[#21] Get rid of deprecated Undertow API

### DIFF
--- a/undertow/src/main/java/org/wildfly/elytron/web/undertow/server/SecurityContextImpl.java
+++ b/undertow/src/main/java/org/wildfly/elytron/web/undertow/server/SecurityContextImpl.java
@@ -64,7 +64,7 @@ public class SecurityContextImpl extends AbstractSecurityContext {
         try {
             return authenticator.authenticate();
         } catch (HttpAuthenticationException e) {
-            exchange.setResponseCode(INTERNAL_SERVER_ERROR);
+            exchange.setStatusCode(INTERNAL_SERVER_ERROR);
 
             return false;
         }

--- a/undertow/src/test/java/org/wildfly/elytron/web/undertow/server/DefaultServer.java
+++ b/undertow/src/test/java/org/wildfly/elytron/web/undertow/server/DefaultServer.java
@@ -33,8 +33,6 @@ import org.junit.runner.notification.RunListener;
 import org.junit.runner.notification.RunNotifier;
 import org.junit.runners.BlockJUnit4ClassRunner;
 import org.junit.runners.model.InitializationError;
-import org.xnio.BufferAllocator;
-import org.xnio.ByteBufferSlicePool;
 import org.xnio.ChannelListener;
 import org.xnio.ChannelListeners;
 import org.xnio.OptionMap;
@@ -44,6 +42,7 @@ import org.xnio.Xnio;
 import org.xnio.XnioWorker;
 import org.xnio.channels.AcceptingChannel;
 
+import io.undertow.server.DefaultByteBufferPool;
 /**
  * Following a similar approach as is used in the Undertow testsuite, a runner that starts up an Undertow server for the first
  * test and keeps it up for re-use until the last test completes.
@@ -136,9 +135,9 @@ public class DefaultServer extends BlockJUnit4ClassRunner {
                 .set(Options.BALANCING_CONNECTIONS, 2)
                 .getMap();
 
-        ByteBufferSlicePool pool = new ByteBufferSlicePool(BufferAllocator.BYTE_BUFFER_ALLOCATOR, 8192, 8192 * 8192);
+        DefaultByteBufferPool pool = new DefaultByteBufferPool(true, 8192 * 3, 1000, 10, 100);
         openListener = new HttpOpenListener(pool, OptionMap.create(UndertowOptions.BUFFER_PIPELINED_DATA, true,
-                UndertowOptions.ENABLE_CONNECTOR_STATISTICS, true));
+                UndertowOptions.ENABLE_STATISTICS, true));
         acceptListener = ChannelListeners.openListenerAdapter(openListener);
 
         server = worker.createStreamConnectionServer(new InetSocketAddress("localhost", 7776), acceptListener, serverOptions);


### PR DESCRIPTION
deprecated setResponseCode is alias for setStatusCode
deprecated ENABLE_CONNECTOR_STATISTICS is alias for ENABLE_STATISTICS
setting of DefaultByteBufferPool is inspired by Undertow equivalent
https://github.com/undertow-io/undertow/blob/a34808b87595b386227beb4cb75a5df6cb8f9c66/core/src/test/java/io/undertow/testutils/DefaultServer.java#L137