### PR TITLE
Ensure TCP connection is closed in test.

### DIFF
--- a/undertow/src/test/java/org/wildfly/elytron/web/undertow/server/ClientCertAuthenticationTest.java
+++ b/undertow/src/test/java/org/wildfly/elytron/web/undertow/server/ClientCertAuthenticationTest.java
@@ -211,6 +211,7 @@ public class ClientCertAuthenticationTest {
                 .set(Options.REUSE_ADDRESSES, true)
                 .set(Options.BALANCING_TOKENS, 1)
                 .set(Options.BALANCING_CONNECTIONS, 2)
+                .set(Options.CLOSE_ABORT, true)
                 .getMap();
 
         /*


### PR DESCRIPTION
There was issue on Windows 2012 ClientCertAuthenticationTest brings
himself into "BindException: Address already in"