### PR TITLE
[ELY-694] Mechanism name should be CLIENT-CERT not CLIENT_CERT.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <description>Integration project for integrating Elytron based HTTP authentication with web containers.</description>
 
     <properties>
-        <version.org.wildfly.security.elytron>1.1.0.Beta10</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.1.0.Beta12-SNAPSHOT</version.org.wildfly.security.elytron>
         <version.org.wildfly.common>1.1.0.Final</version.org.wildfly.common>
         <version.org.apache.httpcomponents.httpclient>4.5</version.org.apache.httpcomponents.httpclient>
         <version.org.apache.httpcomponents.httpcore>4.4.1</version.org.apache.httpcomponents.httpcore>

--- a/undertow/src/test/java/org/wildfly/elytron/web/undertow/server/ClientCertAuthenticationTest.java
+++ b/undertow/src/test/java/org/wildfly/elytron/web/undertow/server/ClientCertAuthenticationTest.java
@@ -140,7 +140,7 @@ public class ClientCertAuthenticationTest extends AbstractHttpServerMechanismTes
 
     @Override
     protected String getMechanismName() {
-        return "CLIENT_CERT";
+        return "CLIENT-CERT";
     }
 
     @Override


### PR DESCRIPTION
Depends on https://github.com/wildfly-security/wildfly-elytron/pull/525
