### PR TITLE
Fix for possible null sessionManager reference (found by Coverity scan)

### DIFF
--- a/undertow/src/main/java/org/wildfly/elytron/web/undertow/server/ElytronHttpExchange.java
+++ b/undertow/src/main/java/org/wildfly/elytron/web/undertow/server/ElytronHttpExchange.java
@@ -368,7 +368,7 @@ public class ElytronHttpExchange implements HttpExchangeSpi {
         SessionManager sessionManager = getSessionManager();
         SessionConfig sessionConfig = getSessionConfig();
 
-        if (sessionManager == null && sessionConfig == null) {
+        if (sessionManager == null || sessionConfig == null) {
             return new HttpScope() {
                 @Override
                 public boolean exists() {


### PR DESCRIPTION
https://scan7.coverity.com/reports.htm#v16159/p12664/fileInstanceId=6892079&defectInstanceId=1794519&mergedDefectId=1388475

> Either the check against `null` is unnecessary, or there may be a null pointer exception.
> In `org.​wildfly.​elytron.​web.​undertow.​server.​ElytronHttpExchange.​toScope(java.​lang.​String)`: Reference is checked against `null` but then dereferenced anyway