### PR TITLE
Incorporate ELY-878 changes to SSO

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,11 +94,12 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${version.surefire.plugin}</version>
                     <configuration>
-                        <argLine>-server -Djava.net.preferIPv4Stack=true</argLine>
+                        <argLine>-server</argLine>
                         <systemPropertyVariables>
                             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                             <log4j.defaultInitOverride>true</log4j.defaultInitOverride>
                             <test.level>${test.level}</test.level>
+                            <java.net.preferIPv4Stack>true</java.net.preferIPv4Stack>
                         </systemPropertyVariables>
                         <redirectTestOutputToFile>${maven.test.redirectTestOutputToFile}</redirectTestOutputToFile>
                         <trimStackTrace>false</trimStackTrace>

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,7 @@
                             <test.level>${test.level}</test.level>
                             <java.net.preferIPv4Stack>true</java.net.preferIPv4Stack>
                             <java.net.preferIPv6Addresses>false</java.net.preferIPv6Addresses>
+                            <jgroups.bind_addr>127.0.0.1</jgroups.bind_addr>
                         </systemPropertyVariables>
                         <redirectTestOutputToFile>${maven.test.redirectTestOutputToFile}</redirectTestOutputToFile>
                         <trimStackTrace>false</trimStackTrace>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <description>Integration project for integrating Elytron based HTTP authentication with web containers.</description>
 
     <properties>
-        <version.org.wildfly.security.elytron>1.1.0.Beta18</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.1.0.Beta20-SNAPSHOT</version.org.wildfly.security.elytron>
         <version.org.wildfly.common>1.2.0.Beta1</version.org.wildfly.common>
         <version.org.apache.httpcomponents.httpclient>4.5</version.org.apache.httpcomponents.httpclient>
         <version.org.apache.httpcomponents.httpcore>4.4.1</version.org.apache.httpcomponents.httpcore>
@@ -46,7 +46,7 @@
         <version.org.jboss.modules>1.6.0.Beta3</version.org.jboss.modules>
         <version.org.jboss.xnio>3.4.1.Final</version.org.jboss.xnio>
         <version.junit.junit>4.11</version.junit.junit>
-        <version.org.infinispan.infinispan-embedded>8.2.3.Final</version.org.infinispan.infinispan-embedded>
+        <version.org.infinispan>8.2.3.Final</version.org.infinispan>
         <version.org.wildfly.checkstyle-config>1.0.3.Final</version.org.wildfly.checkstyle-config>
         <version.com.puppycrawl.tools.checkstyle>6.3</version.com.puppycrawl.tools.checkstyle>
 
@@ -246,8 +246,8 @@
             </dependency>
             <dependency>
                 <groupId>org.infinispan</groupId>
-                <artifactId>infinispan-embedded</artifactId>
-                <version>${version.org.infinispan.infinispan-embedded}</version>
+                <artifactId>infinispan-core</artifactId>
+                <version>${version.org.infinispan}</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,7 @@
                             <log4j.defaultInitOverride>true</log4j.defaultInitOverride>
                             <test.level>${test.level}</test.level>
                             <java.net.preferIPv4Stack>true</java.net.preferIPv4Stack>
+                            <java.net.preferIPv6Addresses>false</java.net.preferIPv6Addresses>
                         </systemPropertyVariables>
                         <redirectTestOutputToFile>${maven.test.redirectTestOutputToFile}</redirectTestOutputToFile>
                         <trimStackTrace>false</trimStackTrace>

--- a/undertow/pom.xml
+++ b/undertow/pom.xml
@@ -98,7 +98,7 @@
         </dependency>
         <dependency>
             <groupId>org.infinispan</groupId>
-            <artifactId>infinispan-embedded</artifactId>
+            <artifactId>infinispan-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/undertow/src/main/java/org/wildfly/elytron/web/undertow/server/ElytronHttpExchange.java
+++ b/undertow/src/main/java/org/wildfly/elytron/web/undertow/server/ElytronHttpExchange.java
@@ -305,8 +305,18 @@ public class ElytronHttpExchange implements HttpExchangeSpi {
         }
 
         switch (scope) {
-            case APPLICATION:
-                return null;
+            case APPLICATION: {
+                SessionManager sessionManager = getSessionManager();
+                if (sessionManager == null) return null;
+
+                return new HttpScope() {
+                    @Override
+                    public String getID() {
+                        // TODO Find a better mechanism for obtaining a unique deployment ID
+                        return sessionManager.getDeploymentName();
+                    }
+                };
+            }
             case CONNECTION:
                 return getScope(httpServerExchange.getConnection());
             case EXCHANGE:

--- a/undertow/src/test/java/org/wildfly/elytron/web/undertow/server/BasicAuthenticationTest.java
+++ b/undertow/src/test/java/org/wildfly/elytron/web/undertow/server/BasicAuthenticationTest.java
@@ -60,7 +60,7 @@ public class BasicAuthenticationTest extends AbstractHttpServerMechanismTest {
     @Test
     public void testUnauthorized() throws Exception {
         HttpClient httpClient = HttpClientBuilder.create().build();
-        HttpGet get = new HttpGet(server.getServerUri());
+        HttpGet get = new HttpGet(server.createUri());
 
         assertUnauthorizedResponse(httpClient.execute(get));
     }
@@ -68,7 +68,7 @@ public class BasicAuthenticationTest extends AbstractHttpServerMechanismTest {
     @Test
     public void testSuccessfulAuthentication() throws Exception {
         HttpClient httpClient = HttpClientBuilder.create().build();
-        HttpGet get = new HttpGet(server.getServerUri());
+        HttpGet get = new HttpGet(server.createUri());
 
         get.addHeader(AUTHORIZATION.toString(), BASIC + " " + FlexBase64.encodeString("elytron:Coleoptera".getBytes(), false));
 
@@ -81,7 +81,7 @@ public class BasicAuthenticationTest extends AbstractHttpServerMechanismTest {
     @Test
     public void testFailedAuthentication() throws Exception {
         HttpClient httpClient = HttpClientBuilder.create().build();
-        HttpGet get = new HttpGet(server.getServerUri());
+        HttpGet get = new HttpGet(server.createUri());
 
         get.addHeader(AUTHORIZATION.toString(), BASIC + " " + FlexBase64.encodeString("elytron:bad_password".getBytes(), false));
 

--- a/undertow/src/test/java/org/wildfly/elytron/web/undertow/server/FormAuthenticationWithClusteredSSOTest.java
+++ b/undertow/src/test/java/org/wildfly/elytron/web/undertow/server/FormAuthenticationWithClusteredSSOTest.java
@@ -48,6 +48,7 @@ import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.manager.DefaultCacheManager;
 import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.remoting.transport.jgroups.JGroupsTransport;
 import org.junit.Rule;
 import org.junit.Test;
 import org.wildfly.elytron.web.undertow.server.util.UndertowServer;
@@ -274,7 +275,7 @@ public class FormAuthenticationWithClusteredSSOTest extends AbstractHttpServerMe
         EmbeddedCacheManager cacheManager = new DefaultCacheManager(
                 GlobalConfigurationBuilder.defaultClusteredBuilder()
                         .globalJmxStatistics().cacheManagerName(cacheManagerName)
-                        .transport().nodeName(cacheManagerName)
+                        .transport().nodeName(cacheManagerName).addProperty(JGroupsTransport.CONFIGURATION_FILE, "fast.xml")
                         .build(),
                 new ConfigurationBuilder()
                         .clustering()

--- a/undertow/src/test/java/org/wildfly/elytron/web/undertow/server/FormAuthenticationWithSessionReplicationTest.java
+++ b/undertow/src/test/java/org/wildfly/elytron/web/undertow/server/FormAuthenticationWithSessionReplicationTest.java
@@ -24,10 +24,10 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 import io.undertow.server.session.SessionManager;
 import org.apache.http.HttpResponse;
+import org.apache.http.NameValuePair;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpGet;
@@ -57,22 +57,27 @@ import org.wildfly.security.permission.PermissionVerifier;
 public class FormAuthenticationWithSessionReplicationTest extends AbstractHttpServerMechanismTest {
 
     @Rule
-    public UndertowServer serverA = new UndertowServer(createRootHttpHandler(createSessionManager()), 7776);
+    public UndertowServer serverA = createUndertowServer(7776);
 
     @Rule
-    public UndertowServer serverB = new UndertowServer(createRootHttpHandler(createSessionManager()), 7777);
+    public UndertowServer serverB = createUndertowServer(7777);
 
     @Rule
-    public UndertowServer serverC = new UndertowServer(createRootHttpHandler(createSessionManager()), 7778);
+    public UndertowServer serverC = createUndertowServer(7778);
+
+    private UndertowServer createUndertowServer(int port) {
+        SessionManager sessionManager = new InfinispanSessionManager(String.valueOf(port));
+        return new UndertowServer(createRootHttpHandler(sessionManager), port, sessionManager.getDeploymentName());
+    }
 
     @Test
     public void testSuccessFulAuthentication() throws Exception {
         HttpClient httpClient = HttpClientBuilder.create().build();
 
-        assertLoginPage(httpClient.execute(new HttpGet(serverA.getServerUri())));
+        assertLoginPage(httpClient.execute(new HttpGet(serverA.createUri())));
 
-        HttpPost httpAuthenticate = new HttpPost(serverA.getServerUri().toString() + "/j_security_check");
-        List parameters = new ArrayList();
+        HttpPost httpAuthenticate = new HttpPost(serverA.createUri("/j_security_check"));
+        List<NameValuePair> parameters = new ArrayList<>();
 
         parameters.add(new BasicNameValuePair("j_username", "ladybird"));
         parameters.add(new BasicNameValuePair("j_password", "Coleoptera"));
@@ -83,8 +88,8 @@ public class FormAuthenticationWithSessionReplicationTest extends AbstractHttpSe
 
         for (int i = 0; i < 2; i++) {
             assertSuccessfulResponse(execute, "ladybird");
-            assertSuccessfulResponse(httpClient.execute(new HttpGet(serverB.getServerUri())), "ladybird");
-            assertSuccessfulResponse(httpClient.execute(new HttpGet(serverC.getServerUri())), "ladybird");
+            assertSuccessfulResponse(httpClient.execute(new HttpGet(serverB.createUri())), "ladybird");
+            assertSuccessfulResponse(httpClient.execute(new HttpGet(serverC.createUri())), "ladybird");
         }
     }
 
@@ -92,11 +97,11 @@ public class FormAuthenticationWithSessionReplicationTest extends AbstractHttpSe
     public void testSessionInvalidation() throws Exception {
         HttpClient httpClient = HttpClientBuilder.create().build();
 
-        assertLoginPage(httpClient.execute(new HttpGet(serverA.getServerUri())));
+        assertLoginPage(httpClient.execute(new HttpGet(serverA.createUri())));
 
         for (int i = 0; i < 10; i++) {
-            HttpPost httpAuthenticate = new HttpPost(serverA.getServerUri().toString() + "/j_security_check");
-            List parameters = new ArrayList();
+            HttpPost httpAuthenticate = new HttpPost(serverA.createUri("/j_security_check"));
+            List<NameValuePair> parameters = new ArrayList<>();
 
             parameters.add(new BasicNameValuePair("j_username", "ladybird"));
             parameters.add(new BasicNameValuePair("j_password", "Coleoptera"));
@@ -106,15 +111,15 @@ public class FormAuthenticationWithSessionReplicationTest extends AbstractHttpSe
             HttpResponse execute = httpClient.execute(httpAuthenticate);
 
             assertSuccessfulResponse(execute, "ladybird");
-            assertSuccessfulResponse(httpClient.execute(new HttpGet(serverA.getServerUri())), "ladybird");
-            assertSuccessfulResponse(httpClient.execute(new HttpGet(serverB.getServerUri())), "ladybird");
-            assertSuccessfulResponse(httpClient.execute(new HttpGet(serverC.getServerUri())), "ladybird");
+            assertSuccessfulResponse(httpClient.execute(new HttpGet(serverA.createUri())), "ladybird");
+            assertSuccessfulResponse(httpClient.execute(new HttpGet(serverB.createUri())), "ladybird");
+            assertSuccessfulResponse(httpClient.execute(new HttpGet(serverC.createUri())), "ladybird");
 
-            httpClient.execute(new HttpGet(serverA.getServerUri().toString() + "/logout"));
+            httpClient.execute(new HttpGet(serverA.createUri("/logout")));
 
-            assertLoginPage(httpClient.execute(new HttpGet(serverC.getServerUri())));
-            assertLoginPage(httpClient.execute(new HttpGet(serverA.getServerUri())));
-            assertLoginPage(httpClient.execute(new HttpGet(serverB.getServerUri())));
+            assertLoginPage(httpClient.execute(new HttpGet(serverC.createUri())));
+            assertLoginPage(httpClient.execute(new HttpGet(serverA.createUri())));
+            assertLoginPage(httpClient.execute(new HttpGet(serverB.createUri())));
         }
     }
 
@@ -141,9 +146,5 @@ public class FormAuthenticationWithSessionReplicationTest extends AbstractHttpSe
         builder.setPermissionMapper((principal, roles) -> PermissionVerifier.from(new LoginPermission()));
 
         return builder.build();
-    }
-
-    private SessionManager createSessionManager() {
-        return new InfinispanSessionManager(UUID.randomUUID().toString());
     }
 }

--- a/undertow/src/test/java/org/wildfly/elytron/web/undertow/server/util/UndertowServer.java
+++ b/undertow/src/test/java/org/wildfly/elytron/web/undertow/server/util/UndertowServer.java
@@ -37,22 +37,32 @@ public class UndertowServer extends ExternalResource {
     private HttpHandler rootHttpHandler = null;
     private final Supplier<SSLContext> serverSslContext;
     private final int port;
+    private final String deploymentName;
 
     public UndertowServer(HttpHandler root) {
         this(root, (Supplier<SSLContext>) null);
     }
 
     public UndertowServer(HttpHandler root, int port) {
-        this(root, port, null);
+        this(root, port, null, null);
+    }
+
+    public UndertowServer(HttpHandler root, int port, String deploymentName) {
+        this(root, port, deploymentName, null);
     }
 
     public UndertowServer(HttpHandler root, Supplier<SSLContext> serverSslContext) {
-        this(root, 7776, serverSslContext);
+        this(root, 7776, null, serverSslContext);
     }
 
     public UndertowServer(HttpHandler root, int port, Supplier<SSLContext> serverSslContext) {
+        this(root, port, null, serverSslContext);
+    }
+
+    public UndertowServer(HttpHandler root, int port, String deploymentName, Supplier<SSLContext> serverSslContext) {
         this.rootHttpHandler = root;
         this.port = port;
+        this.deploymentName = deploymentName;
         this.serverSslContext = serverSslContext;
     }
 
@@ -84,8 +94,12 @@ public class UndertowServer extends ExternalResource {
         server = null;
     }
 
-    public URI getServerUri() throws URISyntaxException {
-        return new URI("http", null, "localhost", port, null, null, null);
+    public URI createUri() throws URISyntaxException {
+        return this.createUri("");
+    }
+
+    public URI createUri(String path) throws URISyntaxException {
+        return new URI((this.serverSslContext != null) ? "https" : "http", null, "localhost", this.port, ((this.deploymentName != null) ? "/" + this.deploymentName : "") + path, null, null);
     }
 
     public void forceShutdown() {


### PR DESCRIPTION
https://issues.jboss.org/browse/ELY-878

Fixes inadvertent JSESSIONID cookie sharing in multi-server tests.

This PR requires a release of wildfly-elytron containing https://github.com/wildfly-security/wildfly-elytron/pull/625