### PR TITLE
Fix for https://github.com/wildfly-security/elytron-web/issues/59

### DIFF
--- a/undertow/src/test/java/org/wildfly/elytron/web/undertow/server/util/KeyPairSupplier.java
+++ b/undertow/src/test/java/org/wildfly/elytron/web/undertow/server/util/KeyPairSupplier.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source
+ *
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.elytron.web.undertow.server.util;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.util.function.Supplier;
+
+/**
+ * @author Paul Ferraro
+ */
+public class KeyPairSupplier implements Supplier<KeyPair> {
+
+    private final KeyPair keyPair;
+
+    public KeyPairSupplier() {
+        try {
+            this.keyPair = KeyPairGenerator.getInstance("RSA").generateKeyPair();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException();
+        }
+    }
+
+    @Override
+    public KeyPair get() {
+        return this.keyPair;
+    }
+}


### PR DESCRIPTION
Use single key pair for test.  Servers need to be able to validate each other's signatures.