### PR TITLE
Resolves #105 If sessions are not supported do not return a dummy scope.

### DIFF
--- a/undertow/src/main/java/org/wildfly/elytron/web/undertow/server/ElytronHttpExchange.java
+++ b/undertow/src/main/java/org/wildfly/elytron/web/undertow/server/ElytronHttpExchange.java
@@ -403,17 +403,7 @@ public class ElytronHttpExchange implements HttpExchangeSpi {
         SessionConfig sessionConfig = getSessionConfig();
 
         if (sessionManager == null || sessionConfig == null) {
-            return new HttpScope() {
-                @Override
-                public boolean exists() {
-                    return false;
-                }
-
-                @Override
-                public boolean create() {
-                    return false;
-                }
-            };
+            return null;
         }
 
         return new HttpScope() {


### PR DESCRIPTION
This was discovered implementing the changes for https://issues.jboss.org/browse/JBEAP-12460 - it is important we can detect if a specific scope is not supported.