### PR TITLE
[ELY-1291] removing non-serializable SecurityIdentity from ElytronAccount

### DIFF
--- a/undertow/src/main/java/org/wildfly/elytron/web/undertow/server/ElytronAccount.java
+++ b/undertow/src/main/java/org/wildfly/elytron/web/undertow/server/ElytronAccount.java
@@ -36,12 +36,12 @@ import org.wildfly.security.auth.server.SecurityIdentity;
  */
 public class ElytronAccount implements Account {
 
-    private final SecurityIdentity securityIdentity;
+    private final Principal principal;
     private final Set<String> roles;
 
     ElytronAccount(final SecurityIdentity securityIdentity) {
         checkNotNullParam("securityIdentity", securityIdentity);
-        this.securityIdentity = securityIdentity;
+        this.principal = securityIdentity.getPrincipal();
         this.roles = Collections.unmodifiableSet(
                 StreamSupport.stream(securityIdentity.getRoles().spliterator(), false).collect(Collectors.toSet()));
     }
@@ -51,7 +51,7 @@ public class ElytronAccount implements Account {
      */
     @Override
     public Principal getPrincipal() {
-        return securityIdentity.getPrincipal();
+        return principal;
     }
 
     /**
@@ -60,15 +60,6 @@ public class ElytronAccount implements Account {
     @Override
     public Set<String> getRoles() {
         return roles;
-    }
-
-    /**
-     * Get the {@link SecurityIdentity} wrapped by this {@link Account}.
-     *
-     * @return the {@link SecurityIdentity} wrapped by this {@link Account}.
-     */
-    SecurityIdentity getSecurityIdentity() {
-        return securityIdentity;
     }
 
 }

--- a/undertow/src/main/java/org/wildfly/elytron/web/undertow/server/ElytronContextAssociationHandler.java
+++ b/undertow/src/main/java/org/wildfly/elytron/web/undertow/server/ElytronContextAssociationHandler.java
@@ -32,23 +32,20 @@ import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
 
 /**
- *
+ * An {@link HttpHandler} responsible for associating the {@link SecurityContextImpl} instance with the current request.
  *
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */
 public class ElytronContextAssociationHandler extends AbstractSecurityContextAssociationHandler {
 
-    private final String programaticMechanismName;
+    private final String programmaticMechanismName;
     private final SecurityDomain securityDomain;
     private final Supplier<List<HttpServerAuthenticationMechanism>> mechanismSupplier;
     private final Function<HttpServerExchange, ElytronHttpExchange> httpExchangeSupplier;
 
-    /**
-     * @param next
-     */
     private ElytronContextAssociationHandler(Builder builder) {
         super(checkNotNullParam("next", builder.next));
-        this.programaticMechanismName = builder.programaticMechanismName != null ? builder.programaticMechanismName : "Programatic";
+        this.programmaticMechanismName = builder.programmaticMechanismName != null ? builder.programmaticMechanismName : "Programmatic";
         this.securityDomain = builder.securityDomain;
         this.mechanismSupplier = checkNotNullParam("mechanismSupplier", builder.mechanismSupplier);
         this.httpExchangeSupplier = checkNotNullParam("httpExchangeSupplier", builder.httpExchangeSupplier);
@@ -61,7 +58,7 @@ public class ElytronContextAssociationHandler extends AbstractSecurityContextAss
     public SecurityContext createSecurityContext(HttpServerExchange exchange) {
         return SecurityContextImpl.builder()
                 .setExchange(exchange)
-                .setProgramaticMechanismName(programaticMechanismName)
+                .setProgrammaticMechanismName(programmaticMechanismName)
                 .setSecurityDomain(securityDomain)
                 .setMechanismSupplier(mechanismSupplier)
                 .setHttpExchangeSupplier(this.httpExchangeSupplier.apply(exchange))
@@ -75,7 +72,7 @@ public class ElytronContextAssociationHandler extends AbstractSecurityContextAss
     public static class Builder {
 
         HttpHandler next;
-        String programaticMechanismName;
+        String programmaticMechanismName;
         SecurityDomain securityDomain;
         Supplier<List<HttpServerAuthenticationMechanism>> mechanismSupplier;
         Function<HttpServerExchange, ElytronHttpExchange> httpExchangeSupplier = ElytronHttpExchange::new;
@@ -89,8 +86,13 @@ public class ElytronContextAssociationHandler extends AbstractSecurityContextAss
             return this;
         }
 
+        @Deprecated
         public Builder setProgramaticMechanismName(final String programaticMechanismName) {
-            this.programaticMechanismName = programaticMechanismName;
+            return this.setProgrammaticMechanismName(programaticMechanismName);
+        }
+
+        public Builder setProgrammaticMechanismName(final String programmaticMechanismName) {
+            this.programmaticMechanismName = programmaticMechanismName;
 
             return this;
         }

--- a/undertow/src/main/java/org/wildfly/elytron/web/undertow/server/ElytronHttpExchange.java
+++ b/undertow/src/main/java/org/wildfly/elytron/web/undertow/server/ElytronHttpExchange.java
@@ -146,7 +146,12 @@ public class ElytronHttpExchange implements HttpExchangeSpi {
     public void authenticationComplete(SecurityIdentity securityIdentity, String mechanismName) {
         SecurityContext securityContext = httpServerExchange.getSecurityContext();
         if (securityContext != null) {
-            securityContext.authenticationComplete(new ElytronAccount(securityIdentity), mechanismName, false);
+            if (securityContext instanceof SecurityContextImpl) {
+                ((SecurityContextImpl) securityContext).authenticationComplete(new ElytronAccount(securityIdentity),
+                        securityIdentity, mechanismName);
+            } else {
+                securityContext.authenticationComplete(new ElytronAccount(securityIdentity), mechanismName, false);
+            }
         }
     }
 

--- a/undertow/src/main/java/org/wildfly/elytron/web/undertow/server/ElytronRunAsHandler.java
+++ b/undertow/src/main/java/org/wildfly/elytron/web/undertow/server/ElytronRunAsHandler.java
@@ -22,12 +22,10 @@ import static org.wildfly.common.Assert.checkNotNullParam;
 import java.util.concurrent.Callable;
 import java.util.function.BiFunction;
 
-import org.wildfly.security.auth.server.FlexibleIdentityAssociation;
-import org.wildfly.security.auth.server.SecurityIdentity;
-
-import io.undertow.security.idm.Account;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
+import org.wildfly.security.auth.server.FlexibleIdentityAssociation;
+import org.wildfly.security.auth.server.SecurityIdentity;
 
 /**
  * A {@link HttpHandler} to be placed after the request has switched to blocking mode to associate the {@link SecurityIdentity}
@@ -55,11 +53,11 @@ public class ElytronRunAsHandler implements HttpHandler {
     @Override
     public void handleRequest(HttpServerExchange exchange) throws Exception {
         SecurityContextImpl securityContext = (SecurityContextImpl) exchange.getSecurityContext();
-        Account account = securityContext != null ? securityContext.getAuthenticatedAccount() : null;
-        SecurityIdentity securityIdentity = (account instanceof ElytronAccount) ? ((ElytronAccount)account).getSecurityIdentity() : null;
+        SecurityIdentity securityIdentity = securityContext != null ? securityContext.getSecurityIdentity() : null;
 
         securityIdentity = identityTransformer.apply(securityIdentity, exchange);
-        FlexibleIdentityAssociation flexibleIdentityAssociation = securityContext.getFlexibleIdentityAssociation();
+        FlexibleIdentityAssociation flexibleIdentityAssociation =
+                securityContext != null ? securityContext.getFlexibleIdentityAssociation() : null;
         if (flexibleIdentityAssociation != null) {
             if(securityIdentity != null){
                 flexibleIdentityAssociation.setIdentity(securityIdentity);

--- a/undertow/src/main/java/org/wildfly/elytron/web/undertow/server/SecurityContextImpl.java
+++ b/undertow/src/main/java/org/wildfly/elytron/web/undertow/server/SecurityContextImpl.java
@@ -23,6 +23,7 @@ import static org.wildfly.common.Assert.checkNotNullParam;
 import java.util.List;
 import java.util.function.Supplier;
 
+import io.undertow.security.idm.Account;
 import org.jboss.logging.Logger;
 import org.wildfly.security.auth.server.FlexibleIdentityAssociation;
 import org.wildfly.security.auth.server.SecurityDomain;
@@ -56,6 +57,8 @@ public class SecurityContextImpl extends AbstractSecurityContext {
 
     private HttpAuthenticator httpAuthenticator;
     private Runnable logoutHandler;
+
+    private SecurityIdentity securityIdentity;
 
     private SecurityContextImpl(Builder builder) {
         super(checkNotNullParam("exchange", builder.exchange));
@@ -124,12 +127,22 @@ public class SecurityContextImpl extends AbstractSecurityContext {
     @Override
     public void logout() {
         super.logout();
+        securityIdentity = null;
         if (logoutHandler != null) {
             logoutHandler.run();
         }
         if(flexibleIdentityAssociation != null) {
             flexibleIdentityAssociation.setIdentity(securityDomain.getAnonymousSecurityIdentity());
         }
+    }
+
+    void authenticationComplete(Account account, SecurityIdentity identity, String mechanism) {
+        super.authenticationComplete(account, mechanism, false, false);
+        securityIdentity = identity;
+    }
+
+    SecurityIdentity getSecurityIdentity() {
+        return securityIdentity;
     }
 
     /**


### PR DESCRIPTION
+ identity as standalone SecurityContext attribute, outside of ElytronAccount
+ handled null securityContext in ElytronRunAsHandler

Second commit:
+ fixed typo in "programmaticMechanismName" param+setter as it was already fixed in SecurityContextImpl

https://issues.jboss.org/browse/ELY-1291