### PR TITLE
[ELYWEB-6] If no RequestDispatcher is available revert to default forwarding behaviour.

### DIFF
--- a/undertow-servlet/src/main/java/org/wildfly/elytron/web/undertow/server/servlet/ElytronHttpServletExchange.java
+++ b/undertow-servlet/src/main/java/org/wildfly/elytron/web/undertow/server/servlet/ElytronHttpServletExchange.java
@@ -84,6 +84,9 @@ class ElytronHttpServletExchange extends ElytronHttpExchange {
         ServletRequest req = servletRequestContext.getServletRequest();
         ServletResponse resp = servletRequestContext.getServletResponse();
         RequestDispatcher disp = req.getRequestDispatcher(path);
+        if (disp == null) {
+            return super.forward(path);
+        }
 
         final FormResponseWrapper respWrapper = httpServerExchange.getStatusCode() != OK && resp instanceof HttpServletResponse
                 ? new FormResponseWrapper((HttpServletResponse) resp) : null;


### PR DESCRIPTION
https://issues.jboss.org/browse/ELYWEB-6