### PR TITLE
 [ELYWEB-18] Add the required ALPNEnginerManager to ensure the SNISSLContext is usable with the ALPN implementation.

### DIFF
--- a/undertow-servlet/pom.xml
+++ b/undertow-servlet/pom.xml
@@ -43,7 +43,7 @@
     </licenses>
 
     <properties>
-        <version.io.undertow>1.4.18.Final</version.io.undertow>
+        <version.io.undertow>2.0.13.Final</version.io.undertow>
         <version.jboss.metadata>11.0.0.Final</version.jboss.metadata>
         <version.org.jboss.spec.jacc>1.0.1.Final</version.org.jboss.spec.jacc>
     </properties>

--- a/undertow/pom.xml
+++ b/undertow/pom.xml
@@ -46,6 +46,18 @@
         <version.io.undertow>2.0.13.Final</version.io.undertow>
     </properties>
 
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <includes>
+                    <include>META-INF/services/*</include>
+                </includes>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+    </build>
+
     <dependencies>
 
         <dependency>

--- a/undertow/pom.xml
+++ b/undertow/pom.xml
@@ -43,7 +43,7 @@
     </licenses>
 
     <properties>
-        <version.io.undertow>1.4.18.Final</version.io.undertow>
+        <version.io.undertow>2.0.13.Final</version.io.undertow>
     </properties>
 
     <dependencies>

--- a/undertow/src/main/java/org/wildfly/elytron/web/undertow/server/sni/SNIAlpnEngineManager.java
+++ b/undertow/src/main/java/org/wildfly/elytron/web/undertow/server/sni/SNIAlpnEngineManager.java
@@ -1,0 +1,41 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.elytron.web.undertow.server.sni;
+
+import java.util.function.Function;
+
+import javax.net.ssl.SSLEngine;
+
+import io.undertow.protocols.alpn.ALPNEngineManager;
+
+import org.wildfly.security.ssl._private.SelectingContext;
+
+public class SNIAlpnEngineManager implements ALPNEngineManager {
+    @Override
+    public int getPriority() {
+        return 100;
+    }
+
+    @Override
+    public boolean registerEngine(SSLEngine engine, Function<SSLEngine, SSLEngine> selectedFunction) {
+        if(!(engine instanceof SelectingContext)) {
+            return false;
+        }
+        SelectingContext snisslEngine = (SelectingContext) engine;
+        snisslEngine.setSelectionCallback(selectedFunction);
+        return true;
+    }
+}

--- a/undertow/src/main/resources/META-INF/services/io.undertow.protocols.alpn.ALPNEngineManager
+++ b/undertow/src/main/resources/META-INF/services/io.undertow.protocols.alpn.ALPNEngineManager
@@ -1,0 +1,15 @@
+#
+# JBoss, Home of Professional Open Source.
+# Copyright 2018 Red Hat, Inc., and individual contributors
+# as indicated by the @author tags.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+org.wildfly.elytron.web.undertow.server.sni.SNIAlpnEngineManager


### PR DESCRIPTION
https://issues.jboss.org/browse/ELYWEB-18

This PR follows up on adding the SNISSLContext in this PR https://github.com/wildfly-security/wildfly-elytron/pull/1188