### PR TITLE
 [ELYWEB-36] Where possible allow the HttpServletRequest to parse the request parameters so it can cache any intermediate results it needs

### DIFF
--- a/undertow/src/main/java/org/wildfly/elytron/web/undertow/server/ElytronHttpExchange.java
+++ b/undertow/src/main/java/org/wildfly/elytron/web/undertow/server/ElytronHttpExchange.java
@@ -83,7 +83,7 @@ public class ElytronHttpExchange implements HttpExchangeSpi {
     private final ScopeSessionListener scopeSessionListener;
 
 
-    private Map<String, List<String>> requestParameters;
+    protected Map<String, List<String>> requestParameters;
 
     protected ElytronHttpExchange(final HttpServerExchange httpServerExchange,
             final Map<Scope, Function<HttpServerExchange, HttpScope>> scopeResolvers,


### PR DESCRIPTION
https://issues.jboss.org/browse/ELYWEB-36