### PR TITLE
[ELYWEB-36] Where possible allow the HttpServletRequest to parse the request parameters so it can cache any intermediate results it needs.

### DIFF
--- a/undertow/src/main/java/org/wildfly/elytron/web/undertow/server/ElytronHttpExchange.java
+++ b/undertow/src/main/java/org/wildfly/elytron/web/undertow/server/ElytronHttpExchange.java
@@ -81,7 +81,7 @@ public class ElytronHttpExchange implements HttpExchangeSpi {
     private final ScopeSessionListener scopeSessionListener;
     private final FormParserFactory formParserFactory = FormParserFactory.builder().build();
 
-    private Map<String, List<String>> requestParameters;
+    protected Map<String, List<String>> requestParameters;
 
     protected ElytronHttpExchange(final HttpServerExchange httpServerExchange,
             final Map<Scope, Function<HttpServerExchange, HttpScope>> scopeResolvers,


### PR DESCRIPTION
Upstream PR https://github.com/wildfly-security/elytron-web/pull/146

https://issues.jboss.org/browse/ELYWEB-36
https://issues.jboss.org/browse/JBEAP-16188