### PR TITLE
[ELYWEB-46] Elytron Bearer Token Authentication - Return a 401 on Invalid Token test fix

### DIFF
--- a/undertow/src/test/java/org/wildfly/elytron/web/undertow/server/BearerTokenAuthenticationTest.java
+++ b/undertow/src/test/java/org/wildfly/elytron/web/undertow/server/BearerTokenAuthenticationTest.java
@@ -88,7 +88,7 @@ public class BearerTokenAuthenticationTest extends AbstractHttpServerMechanismTe
         setBearerToken(get, createToken("alice", new Date(new Date().getTime() - 10000)));
 
         HttpResponse result = httpClient.execute(get);
-        assertEquals(StatusCodes.FORBIDDEN, result.getStatusLine().getStatusCode());
+        assertEquals(StatusCodes.UNAUTHORIZED, result.getStatusLine().getStatusCode());
     }
 
     @Test
@@ -100,7 +100,7 @@ public class BearerTokenAuthenticationTest extends AbstractHttpServerMechanismTe
         setBearerToken(get, createToken("alice", new Date(new Date().getTime() + 10000), generateKeyPair().getPrivate()));
 
         HttpResponse result = httpClient.execute(get);
-        assertEquals(StatusCodes.FORBIDDEN, result.getStatusLine().getStatusCode());
+        assertEquals(StatusCodes.UNAUTHORIZED, result.getStatusLine().getStatusCode());
     }
 
     @Override


### PR DESCRIPTION
https://issues.jboss.org/browse/ELYWEB-46