### PR TITLE
[ELYWEB-79] Ensure the context-path matches how it would be returned from ServletContext.getContextPath();

### DIFF
--- a/undertow-servlet/src/main/java/org/wildfly/elytron/web/undertow/server/servlet/AuthenticationManager.java
+++ b/undertow-servlet/src/main/java/org/wildfly/elytron/web/undertow/server/servlet/AuthenticationManager.java
@@ -167,7 +167,9 @@ public class AuthenticationManager {
             }
         }
 
-        final String applicationContext = deploymentInfo.getHostName() + " " + deploymentInfo.getContextPath();
+        final String deploymentPath = deploymentInfo.getContextPath();
+        final String applicationContext = deploymentInfo.getHostName() + " "
+                + (deploymentPath.equals("/") ? "" : deploymentPath);
 
         HttpHandler contextAssociationHander = ElytronServletContextAssociationHandler.builder()
                 .setApplicationContext(applicationContext)


### PR DESCRIPTION
https://issues.redhat.com/browse/ELYWEB-79