### PR TITLE
[ELYWEB-79] Ensure the context-path matches how it would be returned …

### DIFF
--- a/undertow-servlet/src/main/java/org/wildfly/elytron/web/undertow/server/servlet/AuthenticationManager.java
+++ b/undertow-servlet/src/main/java/org/wildfly/elytron/web/undertow/server/servlet/AuthenticationManager.java
@@ -167,7 +167,9 @@ public class AuthenticationManager {
             }
         }
 
-        final String applicationContext = deploymentInfo.getHostName() + " " + deploymentInfo.getContextPath();
+        final String deploymentPath = deploymentInfo.getContextPath();
+        final String applicationContext = deploymentInfo.getHostName() + " "
+                + (deploymentPath.equals("/") ? "" : deploymentPath);
 
         HttpHandler contextAssociationHander = ElytronServletContextAssociationHandler.builder()
                 .setApplicationContext(applicationContext)


### PR DESCRIPTION
…from ServletContext.getContextPath();

JBEAP(7.3.z):https://issues.redhat.com/browse/JBEAP-18704
Upstream: https://issues.redhat.com/browse/ELYWEB-79
Upstream PR: https://github.com/wildfly-security/elytron-web/pull/159