### PR TITLE
[ELYWEB-99] Add support for External HTTP authentication mechanism in…

### DIFF
--- a/undertow-common-test/src/main/java/org/wildfly/elytron/web/undertow/common/ExternalAuthenticationBase.java
+++ b/undertow-common-test/src/main/java/org/wildfly/elytron/web/undertow/common/ExternalAuthenticationBase.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2020 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.elytron.web.undertow.common;
+
+import static org.wildfly.security.password.interfaces.ClearPassword.ALGORITHM_CLEAR;
+
+import java.security.Principal;
+import java.security.spec.AlgorithmParameterSpec;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Rule;
+import org.wildfly.security.auth.SupportLevel;
+import org.wildfly.security.auth.permission.LoginPermission;
+import org.wildfly.security.auth.realm.SimpleMapBackedSecurityRealm;
+import org.wildfly.security.auth.realm.SimpleRealmEntry;
+import org.wildfly.security.auth.server.RealmIdentity;
+import org.wildfly.security.auth.server.RealmUnavailableException;
+import org.wildfly.security.auth.server.SecurityDomain;
+import org.wildfly.security.auth.server.SecurityRealm;
+import org.wildfly.security.credential.Credential;
+import org.wildfly.security.credential.PasswordCredential;
+import org.wildfly.security.evidence.Evidence;
+import org.wildfly.security.password.PasswordFactory;
+import org.wildfly.security.password.spec.ClearPasswordSpec;
+import org.wildfly.security.permission.PermissionVerifier;
+
+/**
+ * Test case to test the HTTP External mechanism where authentication is backed by Elytron.
+ *
+ * @author <a href="mailto:aabdelsa@redhat.com">Ashley Abdel-Sayed</a>
+ */
+public abstract class ExternalAuthenticationBase extends AbstractHttpServerMechanismTest {
+
+    protected ExternalAuthenticationBase() throws Exception {
+    }
+
+    @Rule
+    public UndertowServer server = createUndertowServer();
+
+    private AtomicInteger realmIdentityInvocationCount = new AtomicInteger(0);
+
+    @Override
+    protected String getMechanismName() {
+        return "EXTERNAL";
+    }
+
+    @Override
+    protected SecurityDomain doCreateSecurityDomain() throws Exception {
+        PasswordFactory passwordFactory = PasswordFactory.getInstance(ALGORITHM_CLEAR);
+        Map<String, SimpleRealmEntry> passwordMap = new HashMap<>();
+
+        passwordMap.put("remoteUser", new SimpleRealmEntry(Collections.singletonList(new PasswordCredential(passwordFactory.generatePassword(new ClearPasswordSpec("doesnotmatter".toCharArray()))))));
+
+        SimpleMapBackedSecurityRealm delegate = new SimpleMapBackedSecurityRealm();
+
+        delegate.setPasswordMap(passwordMap);
+
+        SecurityRealm securityRealm = new SecurityRealm() {
+
+            @Override
+            public RealmIdentity getRealmIdentity(Principal principal) throws RealmUnavailableException {
+                realmIdentityInvocationCount.incrementAndGet();
+                return delegate.getRealmIdentity(principal);
+            }
+
+            @Override
+            public SupportLevel getCredentialAcquireSupport(Class<? extends Credential> credentialType, String algorithmName, AlgorithmParameterSpec algorithmParameterSpec) throws RealmUnavailableException {
+                return delegate.getCredentialAcquireSupport(credentialType, algorithmName, algorithmParameterSpec);
+            }
+
+            @Override
+            public SupportLevel getEvidenceVerifySupport(Class<? extends Evidence> evidenceType, String algorithmName) throws RealmUnavailableException {
+                return delegate.getEvidenceVerifySupport(evidenceType, algorithmName);
+            }
+        };
+
+        SecurityDomain.Builder builder = SecurityDomain.builder()
+                .setDefaultRealmName("TestRealm");
+
+        builder.addRealm("TestRealm", securityRealm).build();
+        builder.setPermissionMapper((principal, roles) -> PermissionVerifier.from(new LoginPermission()));
+
+        return builder.build();
+    }
+
+    protected abstract UndertowServer createUndertowServer() throws Exception;
+}
+

--- a/undertow/src/main/java/org/wildfly/elytron/web/undertow/server/ElytronHttpExchange.java
+++ b/undertow/src/main/java/org/wildfly/elytron/web/undertow/server/ElytronHttpExchange.java
@@ -388,6 +388,11 @@ public class ElytronHttpExchange implements HttpExchangeSpi {
         }
     }
 
+    @Override
+    public String getRemoteUser() {
+        return httpServerExchange.getAttachment(HttpServerExchange.REMOTE_USER);
+    }
+
     /**
      * Sub-types may override this method to define how {@link SessionManager} is obtained.
      *

--- a/undertow/src/test/java/org/wildfly/elytron/web/undertow/server/ExternalSuccessfulAuthenticationTest.java
+++ b/undertow/src/test/java/org/wildfly/elytron/web/undertow/server/ExternalSuccessfulAuthenticationTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.elytron.web.undertow.server;
+
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.LaxRedirectStrategy;
+import org.junit.Test;
+import org.wildfly.elytron.web.undertow.common.ExternalAuthenticationBase;
+import org.wildfly.elytron.web.undertow.common.UndertowServer;
+
+import io.undertow.server.session.InMemorySessionManager;
+
+/**
+ * Test case to test successful authentication with the HTTP External mechanism where authentication is backed by Elytron.
+ *
+ * @author <a href="mailto:aabdelsa@redhat.com">Ashley Abdel-Sayed</a>
+ */
+public class ExternalSuccessfulAuthenticationTest extends ExternalAuthenticationBase {
+
+    public ExternalSuccessfulAuthenticationTest() throws Exception {
+        super();
+    }
+
+    @Test
+    public void testExternalSuccessfulAuthentication() throws Exception {
+        HttpClient httpClient = HttpClientBuilder.create().setRedirectStrategy(new LaxRedirectStrategy()).build();
+        HttpPost httpAuthenticate = new HttpPost(server.createUri("/external_security_check"));
+
+        assertSuccessfulResponse(httpClient.execute(httpAuthenticate), "remoteUser");
+    }
+
+    @Override
+    protected UndertowServer createUndertowServer() throws Exception {
+        return UndertowCoreServer.builder()
+                .setSecurityDomain(getSecurityDomain())
+                .setMechanismFactoryFunction(this::getHttpServerAuthenticationMechanismFactory)
+                .setSessionManager(new InMemorySessionManager(null))
+                .setRemoteUser("remoteUser")
+                .build();
+    }
+
+
+}

--- a/undertow/src/test/java/org/wildfly/elytron/web/undertow/server/ExternalUnsuccessfulAuthenticationTest.java
+++ b/undertow/src/test/java/org/wildfly/elytron/web/undertow/server/ExternalUnsuccessfulAuthenticationTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.elytron.web.undertow.server;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.LaxRedirectStrategy;
+import org.junit.Test;
+import org.wildfly.elytron.web.undertow.common.ExternalAuthenticationBase;
+import org.wildfly.elytron.web.undertow.common.UndertowServer;
+
+import io.undertow.server.session.InMemorySessionManager;
+import io.undertow.util.StatusCodes;
+
+/**
+ * Test case to test unsuccessful authentication with the HTTP External mechanism where authentication is backed by Elytron.
+ *
+ * @author <a href="mailto:aabdelsa@redhat.com">Ashley Abdel-Sayed</a>
+ */
+public class ExternalUnsuccessfulAuthenticationTest extends ExternalAuthenticationBase {
+
+    public ExternalUnsuccessfulAuthenticationTest() throws Exception {
+        super();
+    }
+
+    @Test
+    public void testExternalUnsuccessfulAuthentication() throws Exception {
+        HttpClient httpClient = HttpClientBuilder.create().setRedirectStrategy(new LaxRedirectStrategy()).build();
+        HttpPost httpAuthenticate = new HttpPost(server.createUri("/external_security_check"));
+
+        HttpResponse response = httpClient.execute(httpAuthenticate);
+        assertEquals(StatusCodes.FORBIDDEN, response.getStatusLine().getStatusCode());
+
+
+    }
+
+    @Override
+    protected UndertowServer createUndertowServer() throws Exception {
+        return UndertowCoreServer.builder()
+                .setSecurityDomain(getSecurityDomain())
+                .setMechanismFactoryFunction(this::getHttpServerAuthenticationMechanismFactory)
+                .setSessionManager(new InMemorySessionManager(null))
+                .build();
+    }
+
+
+}

--- a/undertow/src/test/java/org/wildfly/elytron/web/undertow/server/UndertowCoreServer.java
+++ b/undertow/src/test/java/org/wildfly/elytron/web/undertow/server/UndertowCoreServer.java
@@ -107,6 +107,7 @@ public class UndertowCoreServer extends UndertowServer {
         private int port = 7776;
         private String deploymentName;
         private Supplier<SSLContext> serverSslContext;
+        private String remoteUser = null;
 
         public Builder setSecurityDomain(final SecurityDomain securityDomain) {
             this.securityDomain = securityDomain;
@@ -146,6 +147,12 @@ public class UndertowCoreServer extends UndertowServer {
 
         public Builder setSslContext(final Supplier<SSLContext> serverSslContext) {
             this.serverSslContext = serverSslContext;
+
+            return this;
+        }
+
+        public Builder setRemoteUser(final String remoteUser) {
+            this.remoteUser = remoteUser;
 
             return this;
         }
@@ -218,7 +225,11 @@ public class UndertowCoreServer extends UndertowServer {
 
                     sessionManager.registerSessionListener(sessionListener);
 
-                    elytronContextHandlerBuilder.setHttpExchangeSupplier(exchange -> new ElytronHttpExchange(exchange, Collections.emptyMap(), sessionListener));
+                    elytronContextHandlerBuilder.setHttpExchangeSupplier(exchange ->
+                            {
+                                exchange.putAttachment(HttpServerExchange.REMOTE_USER, remoteUser);
+                                return new ElytronHttpExchange(exchange, Collections.emptyMap(), sessionListener);
+                            });
 
                     sessionManager.start();
                 }


### PR DESCRIPTION
… Elytron
https://issues.redhat.com/browse/ELYWEB-99
https://issues.redhat.com/browse/EAP7-1323

To pass CI, this will require an Elytron and Undertow upgrade but this is ready for the changes to be reviewed.
Depends on wildfly-security/wildfly-elytron#1386 and undertow-io/undertow#881
