### PR TITLE
[ELYWEB-125] Make it possible to pass through an alternative IdentityCache Supplier

### DIFF
--- a/undertow-servlet/src/main/java/org/wildfly/elytron/web/undertow/server/servlet/AuthenticationManager.java
+++ b/undertow-servlet/src/main/java/org/wildfly/elytron/web/undertow/server/servlet/AuthenticationManager.java
@@ -33,6 +33,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
@@ -224,7 +225,7 @@ public class AuthenticationManager {
         private Function<String, RunAsIdentityMetaData> runAsMapper;
         private boolean enableJaspi = true;
         private boolean integratedJapi = true;
-        private Function<HttpExchangeSpi, IdentityCache> identityCacheSupplier;
+        private BiFunction<HttpExchangeSpi, String, IdentityCache> identityCacheSupplier;
 
         private boolean built = false;
 
@@ -347,13 +348,13 @@ public class AuthenticationManager {
         }
 
         /**
-         * Set a {@code Function} which can take a {@code HttpExchangeSpi} instance and convert it to an {@code IdentityCache},
-         * this allows for pluggable caching strategies such as SSO.
+         * Set a {@code BiFunction} which can take a {@code HttpExchangeSpi} instance and the authentication mechanism name and convert
+         * it to an {@code IdentityCache}, this allows for pluggable caching strategies such as SSO.
          *
          * @param identityCacheSupplier - A supplier of {@code IdentityCache} instances for the current {@code HttpExchangeSpi}.
          * @return this {@link Builder}
          */
-        public Builder setIdentityCacheSupplier(Function<HttpExchangeSpi, IdentityCache> identityCacheSupplier) {
+        public Builder setIdentityCacheSupplier(BiFunction<HttpExchangeSpi, String, IdentityCache> identityCacheSupplier) {
             assertNotBuilt();
             this.identityCacheSupplier = identityCacheSupplier;
 

--- a/undertow/src/main/java/org/wildfly/elytron/web/undertow/server/SecurityContextImpl.java
+++ b/undertow/src/main/java/org/wildfly/elytron/web/undertow/server/SecurityContextImpl.java
@@ -27,6 +27,7 @@ import org.jboss.logging.Logger;
 import org.wildfly.security.auth.server.FlexibleIdentityAssociation;
 import org.wildfly.security.auth.server.SecurityDomain;
 import org.wildfly.security.auth.server.SecurityIdentity;
+import org.wildfly.security.cache.IdentityCache;
 import org.wildfly.security.http.HttpAuthenticationException;
 import org.wildfly.security.http.HttpAuthenticator;
 import org.wildfly.security.http.HttpServerAuthenticationMechanism;
@@ -52,7 +53,7 @@ public class SecurityContextImpl extends AbstractSecurityContext {
     protected final SecurityDomain securityDomain;
     private final Supplier<List<HttpServerAuthenticationMechanism>> mechanismSupplier;
     private final String programmaticMechanismName;
-
+    private Supplier<IdentityCache> identityCacheSupplier;
     private final FlexibleIdentityAssociation flexibleIdentityAssociation;
 
     private HttpAuthenticator httpAuthenticator;
@@ -66,6 +67,7 @@ public class SecurityContextImpl extends AbstractSecurityContext {
         this.mechanismSupplier = builder.mechanismSupplier;
         this.programmaticMechanismName = builder.programmaticMechanismName;
         this.authMode = builder.authMode;
+        this.identityCacheSupplier = builder.identityCacheSupplier;
         if(securityDomain != null) {
             this.flexibleIdentityAssociation = securityDomain.getAnonymousSecurityIdentity().createFlexibleAssociation();
         } else {
@@ -84,6 +86,7 @@ public class SecurityContextImpl extends AbstractSecurityContext {
 
         this.httpAuthenticator = HttpAuthenticator.builder()
                 .setMechanismSupplier(checkNotNullParam("mechanismSupplier", mechanismSupplier))
+                .setIdentityCacheSupplier(identityCacheSupplier)
                 .setProgrammaticMechanismName(checkNotNullParam("programmaticMechanismName", programmaticMechanismName))
                 .setSecurityDomain(securityDomain)
                 .setHttpExchangeSpi(this.httpExchange)
@@ -180,6 +183,7 @@ public class SecurityContextImpl extends AbstractSecurityContext {
         Supplier<List<HttpServerAuthenticationMechanism>> mechanismSupplier;
         ElytronHttpExchange httpExchange;
         AuthenticationMode authMode;
+        Supplier<IdentityCache> identityCacheSupplier;
 
         protected Builder() {
         }
@@ -218,8 +222,19 @@ public class SecurityContextImpl extends AbstractSecurityContext {
             return this;
         }
 
+        @Deprecated
         Builder setHttpExchangeSupplier(ElytronHttpExchange httpExchange) {
+            return setHttpExchange(httpExchange);
+        }
+
+        Builder setHttpExchange(ElytronHttpExchange httpExchange) {
             this.httpExchange = httpExchange;
+
+            return this;
+        }
+
+        Builder setIdentityCacheSupplier(Supplier<IdentityCache> identityCacheSupplier) {
+            this.identityCacheSupplier = identityCacheSupplier;
 
             return this;
         }


### PR DESCRIPTION
As with the PR for ELY-1626 I am raising this as a draft as I have some follow up to continue post feature freeze.

https://issues.redhat.com/browse/ELYWEB-125

The changes to Elytron Web are relatively small to allow an alternative IdentityCache implementation to be provided for programmatic authentication.

This PR depends on an Elytron release containing https://github.com/wildfly-security/wildfly-elytron/pull/1483