### PR TITLE
[ELYWEB-155] Don't override the deployment's authentication mechanisms when overrideDeploymentConfig is false and the loginConfig is null

### DIFF
--- a/undertow-servlet/src/main/java/org/wildfly/elytron/web/undertow/server/servlet/AuthenticationManager.java
+++ b/undertow-servlet/src/main/java/org/wildfly/elytron/web/undertow/server/servlet/AuthenticationManager.java
@@ -139,12 +139,12 @@ public class AuthenticationManager {
         final Map<String, String> baseConfiguration = Collections.unmodifiableMap(tempBaseConfiguration);
 
         final Map<String, Map<String, String>> selectedMechanisms = new LinkedHashMap<>();
-        if (builder.overrideDeploymentConfig || (loginConfig == null)) {
+        if (builder.overrideDeploymentConfig) {
             final Map<String, String> mechanismConfiguration = baseConfiguration;
             for (String n : availableMechanisms) {
                 selectedMechanisms.put(n, mechanismConfiguration);
             }
-        } else {
+        } else if (loginConfig != null) {
             final List<AuthMethodConfig> authMethods = loginConfig.getAuthMethods();
             if (authMethods.isEmpty()) {
                 throw new IllegalStateException("No authentication mechanisms have been selected.");


### PR DESCRIPTION
https://issues.redhat.com/browse/ELYWEB-155

With WildFly 24, with legacy security, the BASIC authentication mechanism wasn't enabled for deployments without `login-config`.

With WildFly 25, with Elytron, the BASIC authentication mechanism is being enabled for deployments without `login-config` even when the `application-security-domain`'s `override-deployment-configuration` option is set to `false`.

We should make sure that we don't enable HTTP mechanisms by default for the case where no `login-config` is present and `overrideDeploymentConfiguration` is false.

More details can be found in [WFLY-15478](https://issues.redhat.com/browse/WFLY-15478).