### PR TITLE
[ELYWEB-163] Update ElytronHttpExchange#getRequestURI to no longer use the 7 argument URI constructor

### DIFF
--- a/undertow/src/main/java/org/wildfly/elytron/web/undertow/server/ElytronHttpExchange.java
+++ b/undertow/src/main/java/org/wildfly/elytron/web/undertow/server/ElytronHttpExchange.java
@@ -198,9 +198,36 @@ public class ElytronHttpExchange implements HttpExchangeSpi {
                 port = httpServerExchange.getHostPort();
                 path = httpServerExchange.getRequestURI();
             }
-            return new URI(scheme, null, host,
-                    ("http".equals(scheme) && port == 80) || ("https".equals(scheme) && port == 443) ? -1 : port, path,
-                    query == null || "".equals(query) ? null : query, null);
+            StringBuilder uriBuilder = new StringBuilder();
+            if (scheme != null) {
+                uriBuilder.append(scheme);
+                uriBuilder.append(':');
+            }
+            if (host != null) {
+                uriBuilder.append("//");
+                boolean needBrackets = ((host.indexOf(':') >= 0)
+                        && ! host.startsWith("[")
+                        && ! host.endsWith("]"));
+                if (needBrackets) {
+                    uriBuilder.append('[');
+                }
+                uriBuilder.append(host);
+                if (needBrackets) {
+                    uriBuilder.append(']');
+                }
+            }
+            if (! (("http".equals(scheme) && port == 80) || ("https".equals(scheme) && port == 443))) {
+                uriBuilder.append(':');
+                uriBuilder.append(port);
+            }
+            if (path != null) {
+                uriBuilder.append(path);
+            }
+            if (query != null && ! query.isEmpty()) {
+                uriBuilder.append("?");
+                uriBuilder.append(query);
+            }
+            return new URI(uriBuilder.toString());
         } catch (URISyntaxException e) {
             return null;
         }


### PR DESCRIPTION
https://issues.redhat.com/browse/ELYWEB-163