### PR TITLE
[ELYWEB-182] Temporarily add back support for the deprecated HttpAuthenticationFactory.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -276,6 +276,12 @@
             </dependency>
             <dependency>
                 <groupId>org.wildfly.security</groupId>
+                <artifactId>wildfly-elytron-auth-server-deprecated</artifactId>
+                <version>${version.org.wildfly.security.elytron}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.wildfly.security</groupId>
                 <artifactId>wildfly-elytron-base</artifactId>
                 <version>${version.org.wildfly.security.elytron}</version>
                 <scope>provided</scope>

--- a/undertow-servlet/pom.xml
+++ b/undertow-servlet/pom.xml
@@ -100,7 +100,11 @@
             <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-elytron-auth-server</artifactId>
             <scope>provided</scope>
-        </dependency>        
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron-auth-server-deprecated</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-elytron-auth-server-http</artifactId>


### PR DESCRIPTION
https://issues.redhat.com/browse/ELYWEB-182

Having both supported at the same time for a while will make it easier to migrate WildFly and WildFly Core.

As this is a single commit it should be easily revertible.
