### PR TITLE
[ELYWEB-189] IdentityContainer should use CachedIdentity for the identity

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <version.io.undertow>2.2.18.Final</version.io.undertow>
         <version.org.wildfly.security.elytron>2.0.0.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.common>1.5.4.Final</version.org.wildfly.common>
-        <version.org.wildfly.security.jakarta.elytron-ee>3.0.0.Beta2</version.org.wildfly.security.jakarta.elytron-ee>
+        <version.org.wildfly.security.jakarta.elytron-ee>3.0.0.Final</version.org.wildfly.security.jakarta.elytron-ee>
         <version.org.apache.httpcomponents.httpclient>4.5.13</version.org.apache.httpcomponents.httpclient>
         <version.org.apache.httpcomponents.httpcore>4.4.15</version.org.apache.httpcomponents.httpcore>
         <version.org.jboss.logging>3.4.3.Final</version.org.jboss.logging>

--- a/pom.xml
+++ b/pom.xml
@@ -473,5 +473,18 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-
+    <repositories>
+        <repository>
+            <id>public-jboss</id>
+            <name>Public JBoss Repository Group</name>
+            <url>https://repository.jboss.org/nexus/content/groups/public-jboss/</url>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>public-jboss-plugins</id>
+            <name>Public JBoss Repository Group</name>
+            <url>https://repository.jboss.org/nexus/content/groups/public-jboss/</url>
+        </pluginRepository>
+    </pluginRepositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 
     <properties>
         <version.io.undertow>2.2.18.Final</version.io.undertow>
-        <version.org.wildfly.security.elytron>2.0.0.Beta1</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>2.0.0.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.common>1.5.4.Final</version.org.wildfly.common>
         <version.org.wildfly.security.jakarta.elytron-ee>3.0.0.Beta2</version.org.wildfly.security.jakarta.elytron-ee>
         <version.org.apache.httpcomponents.httpclient>4.5.13</version.org.apache.httpcomponents.httpclient>


### PR DESCRIPTION
https://issues.redhat.com/browse/ELYWEB-189
https://issues.redhat.com/browse/ELYWEB-192
https://issues.redhat.com/browse/ELYWEB-194
https://issues.redhat.com/browse/ELYWEB-195

Supersedes https://github.com/wildfly-security/elytron-web/pull/224 so we can get this through CI.