### PR TITLE
[ELYWEB-155] Don't override the deployment's authentication mechanism…

### DIFF
--- a/undertow-servlet/src/main/java/org/wildfly/elytron/web/undertow/server/servlet/AuthenticationManager.java
+++ b/undertow-servlet/src/main/java/org/wildfly/elytron/web/undertow/server/servlet/AuthenticationManager.java
@@ -139,12 +139,12 @@ public class AuthenticationManager {
         final Map<String, String> baseConfiguration = Collections.unmodifiableMap(tempBaseConfiguration);
 
         final Map<String, Map<String, String>> selectedMechanisms = new LinkedHashMap<>();
-        if (builder.overrideDeploymentConfig || (loginConfig == null)) {
+        if (builder.overrideDeploymentConfig) {
             final Map<String, String> mechanismConfiguration = baseConfiguration;
             for (String n : availableMechanisms) {
                 selectedMechanisms.put(n, mechanismConfiguration);
             }
-        } else {
+        } else if (loginConfig != null) {
             final List<AuthMethodConfig> authMethods = loginConfig.getAuthMethods();
             if (authMethods.isEmpty()) {
                 throw new IllegalStateException("No authentication mechanisms have been selected.");


### PR DESCRIPTION
…s when overrideDeploymentConfig is false and the loginConfig is null

Backport to the 1.9.x branch.

Issue: https://issues.redhat.com/browse/JBEAP-23971
Upstream issue: https://issues.redhat.com/browse/ELYWEB-155
Upstream PR: https://github.com/wildfly-security/elytron-web/pull/203