### PR TITLE
[ELYWEB-214] Upgrade Junit to 4.11 -> 4.13.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <version.org.jboss.logmanager.log4j-jboss>1.2.0.Final</version.org.jboss.logmanager.log4j-jboss>
         <version.org.jboss.modules>1.9.1.Final</version.org.jboss.modules>
         <version.org.jboss.xnio>3.8.7.Final</version.org.jboss.xnio>
-        <version.junit.junit>4.11</version.junit.junit>
+        <version.junit.junit>4.13.2</version.junit.junit>
         <version.org.infinispan>9.4.24.Final</version.org.infinispan>
         <version.org.jboss.spec.jboss-json-api_1.0_spec>1.0.1.Final</version.org.jboss.spec.jboss-json-api_1.0_spec>
         <version.org.glassfish.javax.json>1.0.4</version.org.glassfish.javax.json>


### PR DESCRIPTION
[ELYWEB-214] Upgrade Junit to 4.11 -> 4.13.2

https://issues.redhat.com/browse/ELYWEB-214

<img width="1728" alt="image" src="https://github.com/wildfly-security/elytron-web/assets/43786003/97d37b53-ad96-41a8-8022-f7de3c40b2e5">
