### PR TITLE
[ELYWEB-214] Upgrade Junit to 4.11 -> 4.13.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <version.org.jboss.logmanager.log4j-jboss>1.2.0.Final</version.org.jboss.logmanager.log4j-jboss>
         <version.org.jboss.modules>1.9.1.Final</version.org.jboss.modules>
         <version.org.jboss.xnio>3.8.7.Final</version.org.jboss.xnio>
-        <version.junit.junit>4.11</version.junit.junit>
+        <version.junit.junit>4.13.2</version.junit.junit>
         <version.org.infinispan>9.4.24.Final</version.org.infinispan>
         <version.jakarta.json.jakarta-json-api>2.0.0</version.jakarta.json.jakarta-json-api>
         <version.jakarta.servlet.jakarta-servlet-api>6.0.0</version.jakarta.servlet.jakarta-servlet-api>


### PR DESCRIPTION
[ELYWEB-214] Upgrade Junit to 4.11 -> 4.13.2
<img width="1544" alt="Screenshot 2023-10-13 at 11 40 45 PM" src="https://github.com/wildfly-security/elytron-web/assets/43786003/bcfffb46-4d3c-4738-8e95-91e7e8abd918">


