### PR TITLE
[ELYWEB-219] Upgrade wildfly-common to 1.5.4 -> 1.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <properties>
         <version.io.undertow>2.3.7.Final</version.io.undertow>
         <version.org.wildfly.security.elytron>2.2.1.Final</version.org.wildfly.security.elytron>
-        <version.org.wildfly.common>1.5.4.Final</version.org.wildfly.common>
+        <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>
         <version.org.wildfly.security.jakarta.elytron-ee>3.0.1.Final</version.org.wildfly.security.jakarta.elytron-ee>
         <version.org.apache.httpcomponents.httpclient>4.5.13</version.org.apache.httpcomponents.httpclient>
         <version.org.apache.httpcomponents.httpcore>4.4.15</version.org.apache.httpcomponents.httpcore>


### PR DESCRIPTION
[ELYWEB-219] Upgrade wildfly-common to 1.5.4 -> 1.6.0

https://issues.redhat.com/browse/ELYWEB-219