### PR TITLE
[ELYWEB-235] Update CI to also run with SE 21

### DIFF
--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -10,16 +10,17 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}-jdk${{ matrix.java }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+        java: ['11', '21']
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 11
+      - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: ${{ matrix.java }}
       - name: Cache Maven packages
         uses: actions/cache@v2
         with:

--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -10,11 +10,11 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}-jdk${{ matrix.java }}
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        java: ['11', '21']
+        java: ['11', '17', '21']
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK ${{ matrix.java }}


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ELYWEB-235
Builds on https://github.com/wildfly-security/elytron-web/pull/250 to update `runs-on` property 