### PR TITLE
ELYWEB-218 - Upgrade org.jboss.logging:jboss-logging from 3.4.3.Final…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <version.org.wildfly.security.jakarta.elytron-ee>3.0.1.Final</version.org.wildfly.security.jakarta.elytron-ee>
         <version.org.apache.httpcomponents.httpclient>4.5.13</version.org.apache.httpcomponents.httpclient>
         <version.org.apache.httpcomponents.httpcore>4.4.15</version.org.apache.httpcomponents.httpcore>
-        <version.org.jboss.logging>3.4.3.Final</version.org.jboss.logging>
+        <version.org.jboss.logging>3.5.3.Final</version.org.jboss.logging>
         <version.org.jboss.logmanager>2.1.14.Final</version.org.jboss.logmanager>
         <version.org.jboss.logmanager.log4j-jboss>1.2.0.Final</version.org.jboss.logmanager.log4j-jboss>
         <version.org.jboss.modules>1.9.1.Final</version.org.jboss.modules>


### PR DESCRIPTION
… to 3.5.3.Final

Issue: https://issues.redhat.com/browse/ELYWEB-218
Supersedes https://github.com/wildfly-security/elytron-web/pull/247 to remove .vscode folder 