### PR TITLE
[ELYWEB-216] Upgrade org.apache.httpcomponents:httpcore

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <version.org.wildfly.common>1.5.4.Final</version.org.wildfly.common>
         <version.org.wildfly.security.jakarta.elytron-ee>3.0.1.Final</version.org.wildfly.security.jakarta.elytron-ee>
         <version.org.apache.httpcomponents.httpclient>4.5.13</version.org.apache.httpcomponents.httpclient>
-        <version.org.apache.httpcomponents.httpcore>4.4.15</version.org.apache.httpcomponents.httpcore>
+        <version.org.apache.httpcomponents.httpcore>4.4.16</version.org.apache.httpcomponents.httpcore>
         <version.org.jboss.logging>3.4.3.Final</version.org.jboss.logging>
         <version.org.jboss.logmanager>2.1.14.Final</version.org.jboss.logmanager>
         <version.org.jboss.logmanager.log4j-jboss>1.2.0.Final</version.org.jboss.logmanager.log4j-jboss>


### PR DESCRIPTION
Upgraded org.apache.httpcomponents:httpcore from 4.4.15 to 4.4.16

https://issues.redhat.com/browse/ELYWEB-216

Supersedes https://github.com/wildfly-security/elytron-web/pull/255