### PR TITLE
[ELYWEB-248] Upgrade WildFly Elytron to version 2.6.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <properties>
         <version.io.undertow>2.3.10.Final</version.io.undertow>
         <version.org.wildfly.security.elytron>2.6.1.Final</version.org.wildfly.security.elytron>
-        <version.org.wildfly.common>1.5.4.Final</version.org.wildfly.common>
+        <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>
         <version.org.wildfly.security.jakarta.elytron-ee>3.0.1.Final</version.org.wildfly.security.jakarta.elytron-ee>
         <version.org.apache.httpcomponents.httpclient>4.5.13</version.org.apache.httpcomponents.httpclient>
         <version.org.apache.httpcomponents.httpcore>4.4.15</version.org.apache.httpcomponents.httpcore>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 
     <properties>
         <version.io.undertow>2.3.10.Final</version.io.undertow>
-        <version.org.wildfly.security.elytron>2.3.1.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>2.6.1.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.common>1.5.4.Final</version.org.wildfly.common>
         <version.org.wildfly.security.jakarta.elytron-ee>3.0.1.Final</version.org.wildfly.security.jakarta.elytron-ee>
         <version.org.apache.httpcomponents.httpclient>4.5.13</version.org.apache.httpcomponents.httpclient>

--- a/undertow-common-test/src/main/java/org/wildfly/elytron/web/undertow/common/CertificateUtil.java
+++ b/undertow-common-test/src/main/java/org/wildfly/elytron/web/undertow/common/CertificateUtil.java
@@ -1,0 +1,81 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2025 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.elytron.web.undertow.common;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+import javax.security.auth.x500.X500Principal;
+
+import org.wildfly.security.x500.cert.SelfSignedX509CertificateAndSigningKey;
+
+/**
+ * Utility for generating a self signed certificate on demand.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+class CertificateUtil {
+
+    private static final String KEY_ALGORITHM = "RSA";
+    private static final String SIGNATURE_ALGORTHM = "SHA256withRSA";
+    private static final String KEYSTORE_TYPE = "PKCS12";
+    private static final char[] PASSWORD = "Elytron".toCharArray();
+
+    static X509Certificate createSelfSignedIdentity(final String alias, final X500Principal principal,
+            final String workingDir, final String keyStoreName) {
+        SelfSignedX509CertificateAndSigningKey selfSignedIdentity = SelfSignedX509CertificateAndSigningKey.builder()
+                .setDn(principal)
+                .setKeyAlgorithmName(KEY_ALGORITHM)
+                .setSignatureAlgorithmName(SIGNATURE_ALGORTHM)
+                .build();
+
+        X509Certificate selfSignedCertificate = selfSignedIdentity.getSelfSignedCertificate();
+        File keyStoreFile = new File(workingDir, keyStoreName);
+        KeyStore keyStore = createEmptyKeyStore();
+        try {
+            keyStore.setKeyEntry(alias, selfSignedIdentity.getSigningKey(), PASSWORD,
+                    new X509Certificate[] { selfSignedIdentity.getSelfSignedCertificate() });
+            try (OutputStream out = new FileOutputStream(keyStoreFile)) {
+                keyStore.store(out, PASSWORD);
+            }
+        } catch (IOException | KeyStoreException | CertificateException | NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+
+        return selfSignedCertificate;
+    }
+
+    private static KeyStore createEmptyKeyStore() {
+        try {
+            KeyStore ks = KeyStore.getInstance(KEYSTORE_TYPE);
+            ks.load(null, null);
+
+            return ks;
+        } catch (KeyStoreException | NoSuchAlgorithmException | CertificateException | IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/undertow-common-test/src/main/java/org/wildfly/elytron/web/undertow/common/ClientCertAuthenticationBase.java
+++ b/undertow-common-test/src/main/java/org/wildfly/elytron/web/undertow/common/ClientCertAuthenticationBase.java
@@ -19,6 +19,7 @@ package org.wildfly.elytron.web.undertow.common;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.wildfly.elytron.web.undertow.common.CertificateUtil.createSelfSignedIdentity;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -94,8 +95,8 @@ public abstract class ClientCertAuthenticationBase extends AbstractHttpServerMec
                 .setBaseDir(TLS_LOCATION)
                 .setRequestIdentities(Identity.LADYBIRD, Identity.SCARAB) // Create all identities.
                 .build();
-        caGenerationTool.createSelfSignedIdentity("tiger", new X500Principal("CN=Unknown, OU=Unknown, O=Unknown, L=Unknown, ST=Unknown, C=Unknown"),
-                "tiger.keystore");
+        createSelfSignedIdentity("tiger", new X500Principal("CN=Unknown, OU=Unknown, O=Unknown, L=Unknown, ST=Unknown, C=Unknown"),
+                TLS_LOCATION, "tiger.keystore");
     }
 
     @AfterClass


### PR DESCRIPTION
This also includes the backport of the CertificateUtil class needed when using Elytron 2.6.x or later.

https://issues.redhat.com/browse/ELYWEB-248