### PR TITLE
[4.1.x] [ELYWEB-244] Add tests that confirm re-authentication is possible for FORM auth

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <properties>
         <version.io.undertow>2.3.10.Final</version.io.undertow>
         <version.org.wildfly.security.elytron>2.6.1.Final</version.org.wildfly.security.elytron>
-        <version.org.wildfly.common>1.5.4.Final</version.org.wildfly.common>
+        <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>
         <version.org.wildfly.security.jakarta.elytron-ee>3.0.1.Final</version.org.wildfly.security.jakarta.elytron-ee>
         <version.org.apache.httpcomponents.httpclient>4.5.13</version.org.apache.httpcomponents.httpclient>
         <version.org.apache.httpcomponents.httpcore>4.4.15</version.org.apache.httpcomponents.httpcore>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 
     <properties>
         <version.io.undertow>2.3.10.Final</version.io.undertow>
-        <version.org.wildfly.security.elytron>2.6.1.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>2.6.2.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>
         <version.org.wildfly.security.jakarta.elytron-ee>3.0.1.Final</version.org.wildfly.security.jakarta.elytron-ee>
         <version.org.apache.httpcomponents.httpclient>4.5.13</version.org.apache.httpcomponents.httpclient>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 
     <properties>
         <version.io.undertow>2.3.7.Final</version.io.undertow>
-        <version.org.wildfly.security.elytron>2.2.4.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>2.2.9.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.common>1.5.4.Final</version.org.wildfly.common>
         <version.org.wildfly.security.jakarta.elytron-ee>3.0.1.Final</version.org.wildfly.security.jakarta.elytron-ee>
         <version.org.apache.httpcomponents.httpclient>4.5.13</version.org.apache.httpcomponents.httpclient>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 
     <properties>
         <version.io.undertow>2.3.10.Final</version.io.undertow>
-        <version.org.wildfly.security.elytron>2.3.1.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>2.6.1.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.common>1.5.4.Final</version.org.wildfly.common>
         <version.org.wildfly.security.jakarta.elytron-ee>3.0.1.Final</version.org.wildfly.security.jakarta.elytron-ee>
         <version.org.apache.httpcomponents.httpclient>4.5.13</version.org.apache.httpcomponents.httpclient>

--- a/undertow-common-test/src/main/java/org/wildfly/elytron/web/undertow/common/CertificateUtil.java
+++ b/undertow-common-test/src/main/java/org/wildfly/elytron/web/undertow/common/CertificateUtil.java
@@ -1,0 +1,81 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2025 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.elytron.web.undertow.common;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+import javax.security.auth.x500.X500Principal;
+
+import org.wildfly.security.x500.cert.SelfSignedX509CertificateAndSigningKey;
+
+/**
+ * Utility for generating a self signed certificate on demand.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+class CertificateUtil {
+
+    private static final String KEY_ALGORITHM = "RSA";
+    private static final String SIGNATURE_ALGORTHM = "SHA256withRSA";
+    private static final String KEYSTORE_TYPE = "PKCS12";
+    private static final char[] PASSWORD = "Elytron".toCharArray();
+
+    static X509Certificate createSelfSignedIdentity(final String alias, final X500Principal principal,
+            final String workingDir, final String keyStoreName) {
+        SelfSignedX509CertificateAndSigningKey selfSignedIdentity = SelfSignedX509CertificateAndSigningKey.builder()
+                .setDn(principal)
+                .setKeyAlgorithmName(KEY_ALGORITHM)
+                .setSignatureAlgorithmName(SIGNATURE_ALGORTHM)
+                .build();
+
+        X509Certificate selfSignedCertificate = selfSignedIdentity.getSelfSignedCertificate();
+        File keyStoreFile = new File(workingDir, keyStoreName);
+        KeyStore keyStore = createEmptyKeyStore();
+        try {
+            keyStore.setKeyEntry(alias, selfSignedIdentity.getSigningKey(), PASSWORD,
+                    new X509Certificate[] { selfSignedIdentity.getSelfSignedCertificate() });
+            try (OutputStream out = new FileOutputStream(keyStoreFile)) {
+                keyStore.store(out, PASSWORD);
+            }
+        } catch (IOException | KeyStoreException | CertificateException | NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+
+        return selfSignedCertificate;
+    }
+
+    private static KeyStore createEmptyKeyStore() {
+        try {
+            KeyStore ks = KeyStore.getInstance(KEYSTORE_TYPE);
+            ks.load(null, null);
+
+            return ks;
+        } catch (KeyStoreException | NoSuchAlgorithmException | CertificateException | IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/undertow-common-test/src/main/java/org/wildfly/elytron/web/undertow/common/ClientCertAuthenticationBase.java
+++ b/undertow-common-test/src/main/java/org/wildfly/elytron/web/undertow/common/ClientCertAuthenticationBase.java
@@ -19,6 +19,7 @@ package org.wildfly.elytron.web.undertow.common;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.wildfly.elytron.web.undertow.common.CertificateUtil.createSelfSignedIdentity;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -94,8 +95,8 @@ public abstract class ClientCertAuthenticationBase extends AbstractHttpServerMec
                 .setBaseDir(TLS_LOCATION)
                 .setRequestIdentities(Identity.LADYBIRD, Identity.SCARAB) // Create all identities.
                 .build();
-        caGenerationTool.createSelfSignedIdentity("tiger", new X500Principal("CN=Unknown, OU=Unknown, O=Unknown, L=Unknown, ST=Unknown, C=Unknown"),
-                "tiger.keystore");
+        createSelfSignedIdentity("tiger", new X500Principal("CN=Unknown, OU=Unknown, O=Unknown, L=Unknown, ST=Unknown, C=Unknown"),
+                TLS_LOCATION, "tiger.keystore");
     }
 
     @AfterClass

--- a/undertow-common-test/src/main/java/org/wildfly/elytron/web/undertow/common/FormAuthenticationBase.java
+++ b/undertow-common-test/src/main/java/org/wildfly/elytron/web/undertow/common/FormAuthenticationBase.java
@@ -88,7 +88,24 @@ public abstract class FormAuthenticationBase extends AbstractHttpServerMechanism
         httpAuthenticate.setEntity(new UrlEncodedFormEntity(parameters));
 
         assertSuccessfulResponse(httpClient.execute(httpAuthenticate), "ladybird");
-        assertSuccessfulResponse(httpClient.execute(httpAuthenticate), "ladybird");
+
+        HttpGet httpRequest = new HttpGet(server.createUri());
+        assertSuccessfulResponse(httpClient.execute(httpRequest), "ladybird");
+
+        // Now try re-authenticating.
+        httpAuthenticate = new HttpPost(server.createUri("/j_security_check"));
+
+        parameters.clear();
+        parameters.add(new BasicNameValuePair("j_username", "dung"));
+        parameters.add(new BasicNameValuePair("j_password", "Coleopterida"));
+
+        httpAuthenticate.setEntity(new UrlEncodedFormEntity(parameters));
+
+        // This first call triggers a new authentication
+        assertSuccessfulResponse(httpClient.execute(httpAuthenticate), "dung");
+        // This second call verifies the new identity was set
+        assertSuccessfulResponse(httpClient.execute(httpRequest), "dung");
+
     }
 
     @Test
@@ -142,6 +159,7 @@ public abstract class FormAuthenticationBase extends AbstractHttpServerMechanism
         Map<String, SimpleRealmEntry> passwordMap = new HashMap<>();
 
         passwordMap.put("ladybird", new SimpleRealmEntry(Collections.singletonList(new PasswordCredential(passwordFactory.generatePassword(new ClearPasswordSpec("Coleoptera".toCharArray()))))));
+        passwordMap.put("dung", new SimpleRealmEntry(Collections.singletonList(new PasswordCredential(passwordFactory.generatePassword(new ClearPasswordSpec("Coleopterida".toCharArray()))))));
 
         SimpleMapBackedSecurityRealm delegate = new SimpleMapBackedSecurityRealm();
 

--- a/undertow-servlet/src/test/java/org/wildfly/elytron/web/undertow/server/servlet/FormAuthenticationSSOBase.java
+++ b/undertow-servlet/src/test/java/org/wildfly/elytron/web/undertow/server/servlet/FormAuthenticationSSOBase.java
@@ -17,6 +17,8 @@
 package org.wildfly.elytron.web.undertow.server.servlet;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.wildfly.security.password.interfaces.ClearPassword.ALGORITHM_CLEAR;
 
@@ -82,13 +84,13 @@ public abstract class FormAuthenticationSSOBase extends AbstractHttpServerMechan
         return "FORM";
     }
 
-        @Override
+    @Override
     protected SecurityDomain doCreateSecurityDomain() throws Exception {
         PasswordFactory passwordFactory = PasswordFactory.getInstance(ALGORITHM_CLEAR);
         Map<String, SimpleRealmEntry> passwordMap = new HashMap<>();
 
-        passwordMap.put("ladybird",
-                new SimpleRealmEntry(Collections.singletonList(new PasswordCredential(passwordFactory.generatePassword(new ClearPasswordSpec("Coleoptera".toCharArray()))))));
+        passwordMap.put("ladybird", new SimpleRealmEntry(Collections.singletonList(new PasswordCredential(passwordFactory.generatePassword(new ClearPasswordSpec("Coleoptera".toCharArray()))))));
+        passwordMap.put("dung", new SimpleRealmEntry(Collections.singletonList(new PasswordCredential(passwordFactory.generatePassword(new ClearPasswordSpec("Coleopterida".toCharArray()))))));
 
         SimpleMapBackedSecurityRealm delegate = new SimpleMapBackedSecurityRealm();
 
@@ -156,41 +158,67 @@ public abstract class FormAuthenticationSSOBase extends AbstractHttpServerMechan
         assertFalse(cookieStore.getCookies().stream().filter(cookie -> cookie.getName().equals("JSESSIONSSOID")).findAny().isPresent());
 
         // log into APP_A
-        HttpResponse execute = loginToApp(httpClient, this::createUriAppA, "ladybird", "Coleoptera");
+        HttpResponse execute = loginToApp(httpClient, this::createUriAppA, "ladybird", "Coleoptera", false);
         assertTrue(cookieStore.getCookies().stream().filter(cookie -> cookie.getName().equals("JSESSIONSSOID")).findAny().isPresent());
         assertSuccessfulResponse(execute, "ladybird");
         String appOneSessionId = getSessionIdForApp(cookieStore, this::getContextRootAppA);
+        assertNotNull(appOneSessionId);
 
         // can now access APP_B without logging in again
         assertSuccessfulResponse(httpClient.execute(new HttpGet(createUriAppB(null))), "ladybird");
         String appTwoSessionId = getSessionIdForApp(cookieStore, this::getContextRootAppB);
+        assertNotNull(appTwoSessionId);
 
         // log out of APP_A
         httpClient.execute(new HttpGet(createUriAppA("/logout")));
 
         // log into APP_A again
-        execute = loginToApp(httpClient, this::createUriAppA, "ladybird", "Coleoptera");
+        execute = loginToApp(httpClient, this::createUriAppA, "ladybird", "Coleoptera", false);
         assertTrue(cookieStore.getCookies().stream().filter(cookie -> cookie.getName().equals("JSESSIONSSOID")).findAny().isPresent());
         assertSuccessfulResponse(execute, "ladybird");
         String appOneNewSessionId = getSessionIdForApp(cookieStore, this::getContextRootAppA);
 
         // the session ID for APP_A should now be different from the initial session ID
-        assertTrue(appOneSessionId != null && appOneNewSessionId != null && ! appOneSessionId.equals(appOneNewSessionId));
+        assertNotNull(appOneNewSessionId);
+        assertTrue(! appOneSessionId.equals(appOneNewSessionId));
 
         // access APP_B without logging in again
         assertSuccessfulResponse(httpClient.execute(new HttpGet(createUriAppB(null))), "ladybird");
         String appTwoNewSessionId = getSessionIdForApp(cookieStore, this::getContextRootAppB);
 
         // the session ID for APP_B should now be different from the initial session ID
-        assertTrue(appTwoSessionId != null && appTwoNewSessionId != null && ! appTwoSessionId.equals(appTwoNewSessionId));
+        assertNotNull(appTwoNewSessionId);
+        assertTrue(! appTwoSessionId.equals(appTwoNewSessionId));
+
+        // Now try re-authentication
+
+        // log into APP_B as a new user
+        execute = loginToApp(httpClient, this::createUriAppB, "dung", "Coleopterida", true);
+        assertTrue(cookieStore.getCookies().stream().filter(cookie -> cookie.getName().equals("JSESSIONSSOID")).findAny().isPresent());
+        assertSuccessfulResponse(execute, "dung");
+        String appTwoNewNewSessionId = getSessionIdForApp(cookieStore, this::getContextRootAppB);
+
+        // Verify that the session ID changed again.
+        assertNotNull(appTwoNewNewSessionId);
+        assertTrue(! appTwoNewNewSessionId.equals(appTwoNewSessionId));
+
+        // Access App A without logging in again
+        assertSuccessfulResponse(httpClient.execute(new HttpGet(createUriAppA(null))), "dung");
+        String appOneNewNewSessionId = getSessionIdForApp(cookieStore, this::getContextRootAppB);
+
+        // Verify the session ID change
+        assertNotNull("App missing session ID", appOneNewNewSessionId);
+        assertNotEquals("App session ID should have changed", appOneNewSessionId, appOneNewNewSessionId);
     }
 
-    private static HttpResponse loginToApp(HttpClient httpClient, ExceptionFunction<String, URI, Exception> uri, String username, String password) throws Exception {
-        assertLoginPage(httpClient.execute(new HttpGet(uri.apply(null))));
+    private static HttpResponse loginToApp(HttpClient httpClient, ExceptionFunction<String, URI, Exception> uri, String username, String password, boolean reAuth) throws Exception {
+        if (! reAuth) {
+            assertLoginPage(httpClient.execute(new HttpGet(uri.apply(null))));
+        }
         HttpPost httpAuthenticate = new HttpPost(uri.apply("/j_security_check"));
         List<NameValuePair> parameters = new ArrayList<>(2);
-        parameters.add(new BasicNameValuePair("j_username", "ladybird"));
-        parameters.add(new BasicNameValuePair("j_password", "Coleoptera"));
+        parameters.add(new BasicNameValuePair("j_username", username));
+        parameters.add(new BasicNameValuePair("j_password", password));
         httpAuthenticate.setEntity(new UrlEncodedFormEntity(parameters));
         return httpClient.execute(httpAuthenticate);
     }

--- a/undertow-servlet/src/test/java/org/wildfly/elytron/web/undertow/server/servlet/FormAuthenticationSSOBase.java
+++ b/undertow-servlet/src/test/java/org/wildfly/elytron/web/undertow/server/servlet/FormAuthenticationSSOBase.java
@@ -200,11 +200,11 @@ public abstract class FormAuthenticationSSOBase extends AbstractHttpServerMechan
 
         // Verify that the session ID changed again.
         assertNotNull(appTwoNewNewSessionId);
-        assertTrue(! appTwoNewNewSessionId.equals(appTwoNewSessionId));
+        assertNotEquals("App session ID should have changed", appTwoNewSessionId, appTwoNewNewSessionId);
 
         // Access App A without logging in again
         assertSuccessfulResponse(httpClient.execute(new HttpGet(createUriAppA(null))), "dung");
-        String appOneNewNewSessionId = getSessionIdForApp(cookieStore, this::getContextRootAppB);
+        String appOneNewNewSessionId = getSessionIdForApp(cookieStore, this::getContextRootAppA);
 
         // Verify the session ID change
         assertNotNull("App missing session ID", appOneNewNewSessionId);


### PR DESCRIPTION
Forward merges https://github.com/wildfly-security/elytron-web/pull/268 and also includes https://github.com/wildfly-security/elytron-web/pull/269.

Tests expected to fail as we will need an Elytron tag.

May not merge if forward port from the 4.0.x branch but as we don't need an Elytron Web tag may be better to use this PR.

https://issues.redhat.com/browse/ELYWEB-244