### PR TITLE
[ELY-2838] Add additional tests for ELY-1745

### DIFF
--- a/undertow-common-test/src/main/java/org/wildfly/elytron/web/undertow/common/AbstractHttpServerMechanismTest.java
+++ b/undertow-common-test/src/main/java/org/wildfly/elytron/web/undertow/common/AbstractHttpServerMechanismTest.java
@@ -110,6 +110,9 @@ public abstract class AbstractHttpServerMechanismTest {
         HttpServerAuthenticationMechanismFactory delegate = new AggregateServerMechanismFactory(new BasicMechanismFactory(), new BearerMechanismFactory(),
                 new ClientCertMechanismFactory(), new DigestMechanismFactory(), new ExternalMechanismFactory(), new FormMechanismFactory(),
                 new SpnegoMechanismFactory());
+        if (getMechanismName() == null) {
+            return new PropertiesServerMechanismFactory(delegate, properties);
+        }
         return new PropertiesServerMechanismFactory(new FilterServerMechanismFactory(delegate, true, getMechanismName()), properties);
     }
 

--- a/undertow/src/test/java/org/wildfly/elytron/web/undertow/server/AbstractAvailableRealmsCallbackTest.java
+++ b/undertow/src/test/java/org/wildfly/elytron/web/undertow/server/AbstractAvailableRealmsCallbackTest.java
@@ -1,0 +1,52 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.elytron.web.undertow.server;
+
+import org.junit.Rule;
+import org.wildfly.elytron.web.undertow.common.AbstractHttpServerMechanismTest;
+import org.wildfly.elytron.web.undertow.common.UndertowServer;
+import org.wildfly.security.auth.realm.SimpleMapBackedSecurityRealm;
+import org.wildfly.security.auth.server.SecurityDomain;
+
+/**
+ * @author <a href="mailto:mskaceli@redhat.com">Marek Skacelik</a>
+ */
+public abstract class AbstractAvailableRealmsCallbackTest extends AbstractHttpServerMechanismTest {
+
+    @Rule
+    public UndertowServer server = createUndertowServer();
+
+    protected AbstractAvailableRealmsCallbackTest() throws Exception {
+    }
+
+    @Override
+    protected String getMechanismName() {
+        // no filtering
+        return null;
+    }
+
+    @Override
+    protected SecurityDomain doCreateSecurityDomain() throws Exception {
+        return SecurityDomain.builder()
+                .setDefaultRealmName("SimpleRealm")
+                .addRealm("SimpleRealm", new SimpleMapBackedSecurityRealm()).build().build();
+    }
+
+    abstract UndertowServer createUndertowServer() throws Exception;
+
+}

--- a/undertow/src/test/java/org/wildfly/elytron/web/undertow/server/AvailableRealmsCallbackNullConfigurationTest.java
+++ b/undertow/src/test/java/org/wildfly/elytron/web/undertow/server/AvailableRealmsCallbackNullConfigurationTest.java
@@ -1,0 +1,63 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.elytron.web.undertow.server;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.junit.Test;
+import org.wildfly.elytron.web.undertow.common.UndertowServer;
+import org.wildfly.elytron.web.undertow.server.util.LogHandler;
+import org.wildfly.security.auth.server.MechanismConfigurationSelector;
+
+import java.io.File;
+
+import static org.apache.http.HttpStatus.SC_INTERNAL_SERVER_ERROR;
+import static org.jboss.logmanager.Level.ERROR;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author <a href="mailto:mskaceli@redhat.com">Marek Skacelik</a>
+ */
+public class AvailableRealmsCallbackNullConfigurationTest extends AbstractAvailableRealmsCallbackTest {
+
+    private final LogHandler logHandler = new LogHandler("target" + File.separator + "test.log");
+
+    public AvailableRealmsCallbackNullConfigurationTest() throws Exception {
+    }
+
+    @Test
+    public void testNullConfiguration() throws Exception {
+        final String expectedException = "java.lang.IllegalStateException: ELY01119: Unable to resolve MechanismConfiguration for mechanismType='null'";
+        HttpClient httpClient = HttpClientBuilder.create().build();
+        HttpGet httpGet = new HttpGet(server.createUri());
+        HttpResponse response = httpClient.execute(httpGet);
+
+        assertEquals(SC_INTERNAL_SERVER_ERROR, response.getStatusLine().getStatusCode());
+        logHandler.assertLogsContain(expectedException, ERROR);
+    }
+    @Override
+    UndertowServer createUndertowServer() throws Exception {
+        return UndertowCoreServer.builder()
+                .setSecurityDomain(doCreateSecurityDomain())
+                .setMechanismFactoryFunction(this::getHttpServerAuthenticationMechanismFactory)
+                .setMechanismConfigurationSelectorSupplier(() -> MechanismConfigurationSelector.constantSelector(null))
+                .build();
+    }
+}

--- a/undertow/src/test/java/org/wildfly/elytron/web/undertow/server/AvailableRealmsCallbackNullSelectorTest.java
+++ b/undertow/src/test/java/org/wildfly/elytron/web/undertow/server/AvailableRealmsCallbackNullSelectorTest.java
@@ -1,0 +1,63 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.elytron.web.undertow.server;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.wildfly.elytron.web.undertow.common.UndertowServer;
+import org.wildfly.elytron.web.undertow.server.util.LogHandler;
+
+import java.io.File;
+
+import static org.apache.http.HttpStatus.SC_INTERNAL_SERVER_ERROR;
+import static org.junit.Assert.assertNotEquals;
+
+/**
+ * @author <a href="mailto:mskaceli@redhat.com">Marek Skacelik</a>
+ */
+public class AvailableRealmsCallbackNullSelectorTest extends AbstractAvailableRealmsCallbackTest {
+
+    private final LogHandler logHandler = new LogHandler("target" + File.separator + "test.log");
+
+        public AvailableRealmsCallbackNullSelectorTest() throws Exception {
+    }
+
+    @Ignore("ELY-1745")
+    @Test
+    public void testNullSelector() throws Exception {
+        final String expectedException = "java.lang.NullPointerException";
+        HttpClient httpClient = HttpClientBuilder.create().build();
+        HttpGet httpGet = new HttpGet(server.createUri());
+        // fixme: ELY-1745
+        HttpResponse response = httpClient.execute(httpGet);
+        assertNotEquals(SC_INTERNAL_SERVER_ERROR, response.getStatusLine().getStatusCode());
+        logHandler.assertLogsDoNotContain(expectedException);
+    }
+    @Override
+    UndertowServer createUndertowServer() throws Exception {
+        return UndertowCoreServer.builder()
+                .setSecurityDomain(doCreateSecurityDomain())
+                .setMechanismFactoryFunction(this::getHttpServerAuthenticationMechanismFactory)
+                .setMechanismConfigurationSelectorSupplier(() -> null)
+                .build();
+    }
+}

--- a/undertow/src/test/java/org/wildfly/elytron/web/undertow/server/UndertowCoreServer.java
+++ b/undertow/src/test/java/org/wildfly/elytron/web/undertow/server/UndertowCoreServer.java
@@ -108,6 +108,7 @@ public class UndertowCoreServer extends UndertowServer {
         private String deploymentName;
         private Supplier<SSLContext> serverSslContext;
         private String remoteUser = null;
+        private Supplier<MechanismConfigurationSelector> mechanismConfigurationSelectorSupplier;
 
         public Builder setSecurityDomain(final SecurityDomain securityDomain) {
             this.securityDomain = securityDomain;
@@ -163,6 +164,12 @@ public class UndertowCoreServer extends UndertowServer {
             return this;
         }
 
+        public Builder setMechanismConfigurationSelectorSupplier(Supplier<MechanismConfigurationSelector> mechanismConfigurationSelector) {
+            this.mechanismConfigurationSelectorSupplier = mechanismConfigurationSelector;
+
+            return this;
+        }
+
         public UndertowServer build() {
             return new UndertowCoreServer(createRootHttpHandler(), port, deploymentName, serverSslContext);
         }
@@ -177,10 +184,12 @@ public class UndertowCoreServer extends UndertowServer {
 
             return HttpAuthenticationFactory.builder()
                     .setSecurityDomain(securityDomain)
-                    .setMechanismConfigurationSelector(MechanismConfigurationSelector.constantSelector(
-                            MechanismConfiguration.builder()
-                                    .addMechanismRealm(MechanismRealmConfiguration.builder().setRealmName("Elytron Realm").build())
-                                    .build()))
+                    .setMechanismConfigurationSelector(
+                                mechanismConfigurationSelectorSupplier != null ? mechanismConfigurationSelectorSupplier.get() : MechanismConfigurationSelector.constantSelector(
+                                    MechanismConfiguration.builder()
+                                            .addMechanismRealm(MechanismRealmConfiguration.builder().setRealmName("Elytron Realm").build())
+                                            .build())
+                    )
                     .setFactory(factory)
                     .build();
         }

--- a/undertow/src/test/java/org/wildfly/elytron/web/undertow/server/util/LogHandler.java
+++ b/undertow/src/test/java/org/wildfly/elytron/web/undertow/server/util/LogHandler.java
@@ -1,0 +1,116 @@
+/*
+ * JBoss, Home of Professional Open Source
+ *
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.elytron.web.undertow.server.util;
+
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+import java.nio.file.NoSuchFileException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.lang.String.format;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Utility class for parsing log files and asserting the presence of log records – for testing purposes.
+ *
+ * @author <a href="mailto:mskaceli@redhat.com">Marek Skacelik</a>
+ */
+public class LogHandler {
+    private final String logFilePath;
+    // based on the "%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n" => only grouping level and message
+    private static final Pattern LOG_PATTERN = Pattern.compile("\\s+(\\w{4,5})\\s+\\[.*?]\\s+\\(.*?\\)\\s+(.*)$");
+    private final List<LogRecord> logRecords = new ArrayList<>();
+
+    public LogHandler(String logFilePath) {
+        if (logFilePath == null) {
+            throw new IllegalArgumentException("Path to log file must not be null");
+        }
+        this.logFilePath = logFilePath;
+    }
+
+    public void assertLogsContain(String message, Level level) throws IOException {
+        loadLogs();
+        assertTrue(format("Expected log record with level '%s' and message '%s' to be present, the content of all the logs are: %s", level, message, stringifyLogs()),
+                logRecords.stream().anyMatch(logRecord -> logRecord.getLevel().equals(level) && logRecord.getMessage().contains(message)));
+    }
+
+    public void assertLogsContain(String message) throws IOException {
+        loadLogs();
+        assertTrue(format("Expected log record with message '%s' to be present, the content of all the logs are: %s", message, stringifyLogs()),
+                logRecords.stream().anyMatch(logRecord -> logRecord.getMessage().contains(message)));
+    }
+
+    public void assertLogsDoNotContain(String message) throws IOException {
+        loadLogs();
+        assertTrue(format("Expected log record with message '%s' to be absent but it was found in the logs, the content of all the logs are: %s", message, stringifyLogs()),
+                logRecords.stream().noneMatch(logRecord -> logRecord.getMessage().contains(message)));
+    }
+
+    public String stringifyLogs() {
+        StringBuilder logs = new StringBuilder();
+        logRecords.forEach(logRecord -> logs.append(logRecord.getLevel()).append(": ").append(logRecord.getMessage()).append("\n"));
+        return logs.toString();
+    }
+
+    private void loadLogs() throws IOException {
+        logRecords.clear();
+        try (BufferedReader reader = new BufferedReader(new FileReader(logFilePath))) {
+            String line;
+
+            // due to multiline stack traces
+            StringBuilder messageBuilder = new StringBuilder();
+            String currentLevel = null;
+
+            while ((line = reader.readLine()) != null) {
+                Matcher matcher = LOG_PATTERN.matcher(line);
+                if (matcher.find()) {
+                    // New log entry found
+                    if (currentLevel != null) {
+                        // Process the previous log entry
+                        createLogRecord(currentLevel, messageBuilder.toString().trim());
+                        messageBuilder.setLength(0); // Clear the message builder for another log entry
+                    }
+                    currentLevel = matcher.group(1);
+                    messageBuilder.append(matcher.group(2)).append("\n"); // Append the first line of the message
+                } else if (currentLevel != null) {
+                    // Continuation of the current log entry (stack trace, etc.)
+                    messageBuilder.append(line).append("\n");
+                }
+            }
+            // Process the last log entry
+            if (currentLevel != null) {
+                createLogRecord(currentLevel, messageBuilder.toString().trim());
+            }
+        } catch (NoSuchFileException e) {
+            throw new IllegalStateException(format("Log file %s does not exist", logFilePath), e);
+        }
+    }
+
+    private void createLogRecord(String level, String message) {
+        Level logLevel = Level.parse(level);
+        LogRecord logRecord = new LogRecord(logLevel, message);
+        logRecords.add(logRecord);
+    }
+
+}


### PR DESCRIPTION
Due to ELY-1745, the failed test was disabled with `@Ignore("ELY-1745")`. This is for Lukaš's bugfix later.
I had to create a LOG parser since the exceptions are part of the `wildfly-elytron` side (via LOG) and not the client (elytron-web) side, so the tests passed even tho the exception was thrown => I had to create a LOG parser to check the for the exception (ERROR log) explicitly.

https://issues.redhat.com/browse/ELY-2838