### PR TITLE
[ELYWEB-252] ElytronHttpExchange.getRequestURI() returns null if invalid characters are in the path.

### DIFF
--- a/bare-http-util/pom.xml
+++ b/bare-http-util/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2025 Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly.security.elytron-web</groupId>
+        <artifactId>elytron-web-parent</artifactId>
+        <version>1.9.5.CR1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>bare-http-util</artifactId>
+    <packaging>jar</packaging>
+
+    <name>WildFly Elytron Web - Utility for Bare HTTP Requests</name>
+    <description>A HTTP utility for testing only that enables tests to push the boundaries of the specifications.</description>
+
+    <licenses>
+        <license>
+            <name>Apache License 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/bare-http-util/src/main/java/org/wildfly/elytron/web/barehttp/BareHttpClient.java
+++ b/bare-http-util/src/main/java/org/wildfly/elytron/web/barehttp/BareHttpClient.java
@@ -190,7 +190,6 @@ public class BareHttpClient {
                         }
                     }
 
-                    System.out.println("Chunk Size String - '" + chunkSizeString.toString() + "'");
                     chunkSize = Integer.parseInt(chunkSizeString.toString(), 16);
 
 

--- a/bare-http-util/src/main/java/org/wildfly/elytron/web/barehttp/BareHttpClient.java
+++ b/bare-http-util/src/main/java/org/wildfly/elytron/web/barehttp/BareHttpClient.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.SocketChannel;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -131,7 +132,8 @@ public class BareHttpClient {
                     } else if (currentLine.length() > 0) {
                         responseBuilder.processHeader(currentLine.toString());
                     } else {
-                        responseBuilder.setBody(responseMessage);
+                        responseBuilder.setMessageBody(toMessageBody(responseMessage, responseBuilder.getContentLength(),
+                                responseBuilder.isChunkedEncoding()));
                         complete = true;
                     }
 
@@ -142,6 +144,60 @@ public class BareHttpClient {
             }
 
             return responseBuilder != null ? responseBuilder.build() : null;
+        }
+
+        private String toMessageBody(final ByteBuffer byteBuffer, int contentLength, boolean chunkedEncoding) throws IOException {
+            if (!chunkedEncoding) {
+                byte[] bodyBytes = new byte[contentLength];
+                byteBuffer.get(bodyBytes);
+
+                return new String(bodyBytes, StandardCharsets.UTF_8);
+            } else {
+                StringBuilder responseBuilder = new StringBuilder();
+
+                int chunkSize = -1;
+                do {
+                    if (chunkSize > 0) {
+                        byte[] chunkData = new byte[chunkSize];
+                        byteBuffer.get(chunkData);
+                        byteBuffer.get(); // Followed by CR
+                        byteBuffer.get(); // Followed by LF
+                        responseBuilder.append(new String(chunkData, StandardCharsets.UTF_8));
+                    }
+
+                    if (!byteBuffer.hasRemaining()) {
+                        byteBuffer.clear();
+                        socketChannel.read(byteBuffer);
+                        byteBuffer.flip();
+                    }
+
+                    chunkSize = 0;
+                    StringBuilder chunkSizeString = new StringBuilder();
+                    boolean endReached = !byteBuffer.hasRemaining();
+                    while(!endReached) {
+                        char currentChar = (char) byteBuffer.get();
+                        if ( (currentChar >= '0' && currentChar <= '9')
+                                || (currentChar >= 'a' && currentChar <= 'f')
+                                || (currentChar >= 'A' && currentChar <= 'F')) {
+                            chunkSizeString.append(currentChar);
+                        } else if (currentChar == '\r') {
+                            byteBuffer.mark();
+                            if (byteBuffer.hasRemaining() && byteBuffer.get() == '\n') {
+                                endReached = true;
+                            } else {
+                                byteBuffer.reset();
+                            }
+                        }
+                    }
+
+                    System.out.println("Chunk Size String - '" + chunkSizeString.toString() + "'");
+                    chunkSize = Integer.parseInt(chunkSizeString.toString(), 16);
+
+
+                } while (chunkSize > 0);
+
+                return responseBuilder.toString();
+            }
         }
 
         public boolean isConnected() {

--- a/bare-http-util/src/main/java/org/wildfly/elytron/web/barehttp/BareHttpClient.java
+++ b/bare-http-util/src/main/java/org/wildfly/elytron/web/barehttp/BareHttpClient.java
@@ -1,0 +1,168 @@
+/*
+ * JBoss, Home of Professional Open Source
+ *
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.elytron.web.barehttp;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.SocketChannel;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Client for sending and receiving bare HTTP messages.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class BareHttpClient {
+
+    BareHttpClient() {
+    }
+
+    public Target target(final String hostName, final int port) {
+        return new Target(hostName, port);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public class Target {
+
+        private final InetSocketAddress address;
+        private final Map<String, String> cookies = new HashMap<>();
+        private SocketChannel socketChannel;
+
+        Target(final String hostName, final int port) {
+            address = new InetSocketAddress(hostName, port);
+        }
+
+        public String getHost() {
+            return address.getHostName() + ":" + address.getPort();
+        }
+
+        /**
+         * Create a new connection to the target server.
+         *
+         * @return {@code true} if a new connection was created, {@code false} otherwise.
+         * @throws IOException
+         */
+        boolean connect() throws IOException {
+            if (isConnected()) {
+                return false; // As in we are reusing the current connection.
+            }
+
+            socketChannel = SocketChannel.open(address);
+
+            return socketChannel.isConnected();
+        }
+
+        void setCookie(final String cookieName, final String cookieValue) {
+            cookies.put(cookieName, cookieValue);
+        }
+
+        Map<String, String> getCookies() {
+            return cookies;
+        }
+
+        public boolean hasCookie(final String cookieName) {
+            return cookies.containsKey(cookieName);
+        }
+
+        void close() throws IOException {
+            if (isConnected()) {
+                socketChannel.close();
+                socketChannel = null;
+            }
+        }
+
+        BareHttpResponse sendAndReceive(final ByteBuffer request) throws IOException {
+            if (!isConnected()) {
+                throw new IOException("Connection is not open.");
+            }
+
+            while(request.hasRemaining()) {
+                socketChannel.write(request);
+            }
+
+            ByteBuffer responseMessage = ByteBuffer.allocate(1024);
+            socketChannel.read(responseMessage);
+            responseMessage.flip();
+
+            BareHttpResponse.Builder responseBuilder = null;
+            boolean complete = false;
+
+            StringBuilder currentLine = new StringBuilder();
+            while (responseMessage.hasRemaining() && !complete) {
+                char c = (char) responseMessage.get();
+                boolean endOfLine = false;
+                if (c == '\r') {
+                    if (responseMessage.hasRemaining()) {
+                        responseMessage.mark();
+                        char next = (char) responseMessage.get();
+                        if (next == '\n') {
+                            endOfLine = true;
+                        } else {
+                            responseMessage.reset();
+                        }
+                    }
+                } else if (!responseMessage.hasRemaining()) {
+                    endOfLine = true; // We have read all the data.
+                }
+
+                if (endOfLine) {
+                    if (responseBuilder == null) {
+                        responseBuilder = BareHttpResponse.builder(this, currentLine.toString());
+                    } else if (currentLine.length() > 0) {
+                        responseBuilder.processHeader(currentLine.toString());
+                    } else {
+                        responseBuilder.setBody(responseMessage);
+                        complete = true;
+                    }
+
+                    currentLine = new StringBuilder();
+                } else {
+                    currentLine.append(c);
+                }
+            }
+
+            return responseBuilder != null ? responseBuilder.build() : null;
+        }
+
+        public boolean isConnected() {
+            return socketChannel != null && socketChannel.isConnected();
+        }
+
+        public BareHttpRequest.Builder buildRequest(final String path) {
+            return BareHttpRequest.builder(this, path);
+        }
+
+    }
+
+
+    public static class Builder {
+
+        Builder() {
+        }
+
+        public BareHttpClient build() {
+            return new BareHttpClient();
+        }
+
+    }
+}

--- a/bare-http-util/src/main/java/org/wildfly/elytron/web/barehttp/BareHttpConstants.java
+++ b/bare-http-util/src/main/java/org/wildfly/elytron/web/barehttp/BareHttpConstants.java
@@ -1,0 +1,59 @@
+/*
+ * JBoss, Home of Professional Open Source
+ *
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.elytron.web.barehttp;
+
+/**
+ * Constants used by the Bare HTTP Utility.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+class BareHttpConstants {
+
+    private BareHttpConstants() {}
+
+    static final String USER_AGENT = "Bare HTTP Test Utility";
+
+    static final String CRLF = "\r\n";
+
+    /*
+     * Response Header Names
+     */
+    static final String CONNECTION_HEADER_NAME = "Connection";
+    static final String CONTENT_LENGTH_HEADER_NAME = "Content-Length";
+    static final String SET_COOKIE_HEADER_NAME = "Set-Cookie";
+    static final String TRANSFER_ENCODING_COOKIE_NAME = "Transfer-Encoding";
+
+    /*
+     * Header Values
+     */
+    static final String CHUNKED_VALUE = "chunked";
+    static final String KEEP_ALIVE_VALUE = "keep-alive";
+
+    /*
+     * Request Header Templates
+     */
+    static final String ACCEPT_ENCODING_HEADER = "Accept-Encoding: gzip,deflate";
+    static final String CONNECTION_HEADER = CONNECTION_HEADER_NAME + ": " + KEEP_ALIVE_VALUE;
+    static final String CONTENT_LENGTH_HEADER = CONTENT_LENGTH_HEADER_NAME + ": %d";
+    static final String CONTENT_TYPE_HEADER = "Content-Type: application/x-www-form-urlencoded";
+    static final String COOKIE_HEADER = "Cookie: %s=%s";
+    static final String GET_HEADER = "GET %s HTTP/1.1";
+    static final String HOST_HEADER = "Host: %s";
+    static final String POST_HEADER = "POST %s HTTP/1.1";
+    static final String USER_AGENT_HEADER = "User-Agent: %s";
+}

--- a/bare-http-util/src/main/java/org/wildfly/elytron/web/barehttp/BareHttpRequest.java
+++ b/bare-http-util/src/main/java/org/wildfly/elytron/web/barehttp/BareHttpRequest.java
@@ -1,0 +1,129 @@
+/*
+ * JBoss, Home of Professional Open Source
+ *
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.elytron.web.barehttp;
+
+import static org.wildfly.elytron.web.barehttp.BareHttpConstants.ACCEPT_ENCODING_HEADER;
+import static org.wildfly.elytron.web.barehttp.BareHttpConstants.CONNECTION_HEADER;
+import static org.wildfly.elytron.web.barehttp.BareHttpConstants.CONTENT_LENGTH_HEADER;
+import static org.wildfly.elytron.web.barehttp.BareHttpConstants.CONTENT_TYPE_HEADER;
+import static org.wildfly.elytron.web.barehttp.BareHttpConstants.COOKIE_HEADER;
+import static org.wildfly.elytron.web.barehttp.BareHttpConstants.CRLF;
+import static org.wildfly.elytron.web.barehttp.BareHttpConstants.GET_HEADER;
+import static org.wildfly.elytron.web.barehttp.BareHttpConstants.HOST_HEADER;
+import static org.wildfly.elytron.web.barehttp.BareHttpConstants.POST_HEADER;
+import static org.wildfly.elytron.web.barehttp.BareHttpConstants.USER_AGENT;
+import static org.wildfly.elytron.web.barehttp.BareHttpConstants.USER_AGENT_HEADER;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.wildfly.elytron.web.barehttp.BareHttpClient.Target;
+
+/**
+ * Representation of an HTTP Request.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class BareHttpRequest {
+
+    private final Target target;
+    private final String path;
+    private final String messageBody;
+
+    BareHttpRequest(final Target target, final String path, final String messageBody) {
+        this.target = target;
+        this.path = path;
+        this.messageBody = messageBody;
+    }
+
+    public BareHttpResponse execute() throws IOException {
+        target.connect();
+
+        ByteBuffer requestMessage = createRequestByteBuffer();
+        return target.sendAndReceive(requestMessage);
+    }
+
+    private ByteBuffer createRequestByteBuffer() {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PrintWriter writer = new PrintWriter(baos);
+        // Now add the headers.
+        int contentLength = messageBody.length();
+        writer.printf(contentLength > 0 ? POST_HEADER : GET_HEADER, path);
+        writer.print(CRLF);
+        if (contentLength > 0) {
+            writer.printf(CONTENT_LENGTH_HEADER, contentLength);
+            writer.print(CRLF);
+            writer.print(CONTENT_TYPE_HEADER);
+            writer.print(CRLF);
+        }
+        writer.printf(HOST_HEADER, target.getHost());
+        writer.print(CRLF);
+        writer.print(CONNECTION_HEADER);
+        writer.print(CRLF);
+        writer.printf(USER_AGENT_HEADER, USER_AGENT);
+        writer.print(CRLF);
+        Map<String, String> cookies = target.getCookies();
+        for (Entry<String, String> current : cookies.entrySet()) {
+            writer.printf(COOKIE_HEADER, current.getKey(), current.getValue());
+            writer.print(CRLF);
+        }
+        writer.print(ACCEPT_ENCODING_HEADER);
+        writer.print(CRLF);
+        writer.print(CRLF);
+        if (contentLength > 0) {
+            writer.print(messageBody);
+        }
+        writer.flush();
+
+        byte[] message = baos.toByteArray();
+        ByteBuffer messageBuffer = ByteBuffer.wrap(message);
+
+        return messageBuffer;
+    }
+
+    static Builder builder(final Target target, final String path) {
+        return new Builder(target, path);
+    }
+
+    public static class Builder {
+
+        private final Target target;
+        private final String path;
+        private String messageBody = "";
+
+        Builder(final Target target, final String path) {
+            this.target = target;
+            this.path = path.trim().isEmpty() ? "/" : path;
+        }
+
+        public Builder setMessageBody(final String messageBody) {
+            this.messageBody = messageBody;
+
+            return this;
+        }
+
+        public BareHttpRequest build() {
+            return new BareHttpRequest(target, path, messageBody);
+        }
+
+    }
+}

--- a/bare-http-util/src/main/java/org/wildfly/elytron/web/barehttp/BareHttpResponse.java
+++ b/bare-http-util/src/main/java/org/wildfly/elytron/web/barehttp/BareHttpResponse.java
@@ -25,8 +25,6 @@ import static org.wildfly.elytron.web.barehttp.BareHttpConstants.SET_COOKIE_HEAD
 import static org.wildfly.elytron.web.barehttp.BareHttpConstants.TRANSFER_ENCODING_COOKIE_NAME;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -52,7 +50,7 @@ public class BareHttpResponse {
         this.headers = builder.headers;
         this.contentLength = builder.contentLength;
         this.chunkedEncoding = builder.chunkedEncoding;
-        this.messageBody = toMessageBody(builder.messageBody, contentLength, chunkedEncoding);
+        this.messageBody = builder.messageBody;
     }
 
     public int getStatusCode() {
@@ -75,16 +73,6 @@ public class BareHttpResponse {
         return chunkedEncoding;
     }
 
-    private static String toMessageBody(final ByteBuffer byteBuffer, int contentLength, boolean chunkedEncoding) {
-        if (!chunkedEncoding) {
-            byte[] bodyBytes = new byte[contentLength];
-            byteBuffer.get(bodyBytes);
-
-            return new String(bodyBytes, StandardCharsets.UTF_8);
-        } else {
-            return "";
-        }
-    }
 
     static Builder builder(final Target target, final String statusLine) {
         if (!statusLine.startsWith("HTTP/1.1")) {
@@ -101,7 +89,7 @@ public class BareHttpResponse {
         private final Target target;
         final int statusCode;
         final Map<String, List<String>> headers = new HashMap<>();
-        ByteBuffer messageBody;
+        String messageBody;
         boolean closeConnection = true;
         int contentLength = -1;
         boolean chunkedEncoding = false;
@@ -109,6 +97,14 @@ public class BareHttpResponse {
         Builder(final Target target, final int statusCode) {
             this.target = target;
             this.statusCode = statusCode;
+        }
+
+        boolean isChunkedEncoding() {
+            return chunkedEncoding;
+        }
+
+        int getContentLength() {
+            return contentLength;
         }
 
         Builder processHeader(final String header) {
@@ -154,7 +150,7 @@ public class BareHttpResponse {
             return this;
         }
 
-        Builder setBody(final ByteBuffer messageBody) {
+        Builder setMessageBody(final String messageBody) {
             this.messageBody = messageBody;
 
             return this;

--- a/bare-http-util/src/main/java/org/wildfly/elytron/web/barehttp/BareHttpResponse.java
+++ b/bare-http-util/src/main/java/org/wildfly/elytron/web/barehttp/BareHttpResponse.java
@@ -1,0 +1,170 @@
+/*
+ * JBoss, Home of Professional Open Source
+ *
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.elytron.web.barehttp;
+
+import static org.wildfly.elytron.web.barehttp.BareHttpConstants.CHUNKED_VALUE;
+import static org.wildfly.elytron.web.barehttp.BareHttpConstants.CONNECTION_HEADER_NAME;
+import static org.wildfly.elytron.web.barehttp.BareHttpConstants.CONTENT_LENGTH_HEADER_NAME;
+import static org.wildfly.elytron.web.barehttp.BareHttpConstants.KEEP_ALIVE_VALUE;
+import static org.wildfly.elytron.web.barehttp.BareHttpConstants.SET_COOKIE_HEADER_NAME;
+import static org.wildfly.elytron.web.barehttp.BareHttpConstants.TRANSFER_ENCODING_COOKIE_NAME;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.wildfly.elytron.web.barehttp.BareHttpClient.Target;
+
+/**
+ * Representation of an HTTP Response.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class BareHttpResponse {
+
+    private final int statusCode;
+    private final Map<String, List<String>> headers;
+    private final String messageBody;
+    private final int contentLength;
+    private final boolean chunkedEncoding;
+
+    BareHttpResponse(final Builder builder) {
+        this.statusCode = builder.statusCode;
+        this.headers = builder.headers;
+        this.contentLength = builder.contentLength;
+        this.chunkedEncoding = builder.chunkedEncoding;
+        this.messageBody = toMessageBody(builder.messageBody, contentLength, chunkedEncoding);
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    public Map<String, List<String>> getHeaders() {
+        return headers;
+    }
+
+    public String getMessageBody() {
+        return messageBody;
+    }
+
+    public int getContentLength() {
+        return contentLength;
+    }
+
+    public boolean isChunkedEncoding() {
+        return chunkedEncoding;
+    }
+
+    private static String toMessageBody(final ByteBuffer byteBuffer, int contentLength, boolean chunkedEncoding) {
+        if (!chunkedEncoding) {
+            byte[] bodyBytes = new byte[contentLength];
+            byteBuffer.get(bodyBytes);
+
+            return new String(bodyBytes, StandardCharsets.UTF_8);
+        } else {
+            return "";
+        }
+    }
+
+    static Builder builder(final Target target, final String statusLine) {
+        if (!statusLine.startsWith("HTTP/1.1")) {
+            throw new IllegalStateException("Not a HTTP/1.1 Response");
+        }
+
+        int statusCode = Integer.parseInt(statusLine.substring(9, 12));
+
+        return new Builder(target, statusCode);
+    }
+
+    static class Builder {
+
+        private final Target target;
+        final int statusCode;
+        final Map<String, List<String>> headers = new HashMap<>();
+        ByteBuffer messageBody;
+        boolean closeConnection = true;
+        int contentLength = -1;
+        boolean chunkedEncoding = false;
+
+        Builder(final Target target, final int statusCode) {
+            this.target = target;
+            this.statusCode = statusCode;
+        }
+
+        Builder processHeader(final String header) {
+            int colonPos = header.indexOf(':');
+            String headerName = header.substring(0, colonPos);
+            String headerValue = header.substring(colonPos + 2);
+
+            List<String> values;
+            if (headers.containsKey(headerName)) {
+                values = headers.get(headerName);
+            } else {
+                values = new ArrayList<>();
+                headers.put(headerName, values);
+            }
+            values.add(headerValue);
+
+            switch (headerName) {
+                case CONNECTION_HEADER_NAME:
+                    if (KEEP_ALIVE_VALUE.equals(headerValue)) {
+                        closeConnection = false;
+                    }
+                    break;
+                case CONTENT_LENGTH_HEADER_NAME:
+                    contentLength = Integer.parseInt(headerValue);
+                    chunkedEncoding = false;
+                    break;
+                case SET_COOKIE_HEADER_NAME:
+                    int equalsPos = headerValue.indexOf('=');
+                    String cookieName = headerValue.substring(0, equalsPos);
+                    int semiPos = headerValue.indexOf(';');
+                    String cookieValue = semiPos < 0 ? headerValue.substring(equalsPos + 1) :
+                            headerValue.substring(equalsPos + 1, semiPos);
+                    target.setCookie(cookieName, cookieValue);
+                    break;
+                case TRANSFER_ENCODING_COOKIE_NAME:
+                    if (CHUNKED_VALUE.equals(headerValue)) {
+                        contentLength = -1;
+                        chunkedEncoding = true;
+                    }
+                    break;
+            }
+
+            return this;
+        }
+
+        Builder setBody(final ByteBuffer messageBody) {
+            this.messageBody = messageBody;
+
+            return this;
+        }
+
+        public BareHttpResponse build() throws IOException {
+            if (closeConnection) {
+                target.close();
+            }
+            return new BareHttpResponse(this);
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@
     </properties>
 
     <modules>
+        <module>bare-http-util</module>
         <module>undertow</module>
         <module>undertow-common-test</module>
         <module>undertow-servlet</module>
@@ -210,6 +211,11 @@
                   Elytron Web Dependencies
              -->
 
+            <dependency>
+                <groupId>org.wildfly.security.elytron-web</groupId>
+                <artifactId>bare-http-util</artifactId>
+                <version>${project.version}</version>
+            </dependency>
             <dependency>
                 <groupId>org.wildfly.security.elytron-web</groupId>
                 <artifactId>undertow-server</artifactId>

--- a/undertow-common-test/pom.xml
+++ b/undertow-common-test/pom.xml
@@ -121,6 +121,10 @@
             <artifactId>wildfly-elytron-x500-deprecated</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wildfly.security.elytron-web</groupId>
+            <artifactId>bare-http-util</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.nimbusds</groupId>
             <artifactId>nimbus-jose-jwt</artifactId>
         </dependency>

--- a/undertow-common-test/src/main/java/org/wildfly/elytron/web/undertow/common/FormAuthenticationBase.java
+++ b/undertow-common-test/src/main/java/org/wildfly/elytron/web/undertow/common/FormAuthenticationBase.java
@@ -18,8 +18,10 @@
 package org.wildfly.elytron.web.undertow.common;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.wildfly.security.password.interfaces.ClearPassword.ALGORITHM_CLEAR;
 
+import java.net.URI;
 import java.security.Principal;
 import java.security.spec.AlgorithmParameterSpec;
 import java.util.ArrayList;
@@ -39,6 +41,9 @@ import org.apache.http.impl.client.LaxRedirectStrategy;
 import org.apache.http.message.BasicNameValuePair;
 import org.junit.Rule;
 import org.junit.Test;
+import org.wildfly.elytron.web.barehttp.BareHttpClient;
+import org.wildfly.elytron.web.barehttp.BareHttpRequest;
+import org.wildfly.elytron.web.barehttp.BareHttpResponse;
 import org.wildfly.security.auth.SupportLevel;
 import org.wildfly.security.auth.permission.LoginPermission;
 import org.wildfly.security.auth.realm.SimpleMapBackedSecurityRealm;
@@ -128,7 +133,69 @@ public abstract class FormAuthenticationBase extends AbstractHttpServerMechanism
         httpClient.execute(new HttpGet(server.createUri("/logout")));
 
         assertLoginPage(httpClient.execute(new HttpGet(server.createUri())));
+    }
 
+    private static final String J_SECURITY_DATA = "j_username=%s&j_password=%s";
+
+    /**
+     * Test case that tests a FORM authentication flow but with non-encoded
+     * characters in the initial request.
+     *
+     * Generally it is not recommended to use this but Undertow allows this to
+     * be enabled so Elytron needs to support it.
+     */
+    @Test
+    public void testNonEncodedURL() throws Exception {
+        URI defaultUri = server.createUri();
+
+        BareHttpClient httpClient = BareHttpClient.builder().build();
+
+        final String hostName = defaultUri.getHost();
+        final int port = defaultUri.getPort();
+
+        BareHttpClient.Target targetServer = httpClient.target(hostName, port);
+
+        BareHttpRequest initialRequest = targetServer.buildRequest(defaultUri.getPath()).build();
+        BareHttpResponse httpResponse = initialRequest.execute();
+
+        assertTrue("Response should set JSESSIONID", targetServer.hasCookie("JSESSIONID"));
+        if (httpResponse.getStatusCode() == 302) {
+            // Now get the location we were redirected to before processing to check the login page.
+            String location = httpResponse.getHeaders().get("Location").get(0);
+            URI locationUri = new URI(location);
+
+            assertEquals("Expected same hostName on redirect", hostName, locationUri.getHost());
+            assertEquals("Expected same port on redirect", port, locationUri.getPort());
+
+            httpResponse = targetServer.buildRequest(locationUri.getPath())
+                    .build().execute();
+        }
+        // This first request should have resulted in the login page being returned.
+        // The end result should be a HTTP 200 status code.
+        assertEquals("Expected Success", 200, httpResponse.getStatusCode());
+        assertTrue("We expect the login page.", httpResponse.getMessageBody().contains("Login Page"));
+
+        URI jSecurityCheckUri = server.createUri("/j_security_check");
+        String messageBody = String.format(J_SECURITY_DATA, "ladybird", "Coleoptera");
+
+        httpResponse = targetServer.buildRequest(jSecurityCheckUri.getPath())
+                .setMessageBody(messageBody)
+                .build()
+                .execute();
+
+        assertEquals("Expected Redirect", 302, httpResponse.getStatusCode());
+        String location = httpResponse.getHeaders().get("Location").get(0);
+        URI locationUri = new URI(location);
+
+        assertEquals("Expected same hostName on redirect", hostName, locationUri.getHost());
+        assertEquals("Expected same port on redirect", port, locationUri.getPort());
+
+        httpResponse = targetServer.buildRequest(locationUri.getPath())
+                .build().execute();
+
+        assertEquals("Expected Success", 200, httpResponse.getStatusCode());
+        assertEquals("Expected UndertowUser", "ladybird", httpResponse.getHeaders().get("UndertowUser").get(0));
+        assertEquals("Expected ElytronUser", "ladybird", httpResponse.getHeaders().get("ElytronUser").get(0));
     }
 
     @Override

--- a/undertow-common-test/src/main/java/org/wildfly/elytron/web/undertow/common/FormAuthenticationBase.java
+++ b/undertow-common-test/src/main/java/org/wildfly/elytron/web/undertow/common/FormAuthenticationBase.java
@@ -30,6 +30,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
 
 import org.apache.http.NameValuePair;
 import org.apache.http.client.HttpClient;
@@ -138,14 +139,12 @@ public abstract class FormAuthenticationBase extends AbstractHttpServerMechanism
     private static final String J_SECURITY_DATA = "j_username=%s&j_password=%s";
 
     /**
-     * Test case that tests a FORM authentication flow but with non-encoded
-     * characters in the initial request.
-     *
-     * Generally it is not recommended to use this but Undertow allows this to
-     * be enabled so Elytron needs to support it.
+     * Common method for tests using the {@code BareHttpClient} implementation.
+     * @param initialPath
+     * @param redirectVerifier
+     * @throws Exception
      */
-    @Test
-    public void testNonEncodedURL() throws Exception {
+    public void bareHttpClientRunner(final String initialPath, Predicate<URI> redirectVerifier) throws Exception {
         URI defaultUri = server.createUri();
 
         BareHttpClient httpClient = BareHttpClient.builder().build();
@@ -155,7 +154,7 @@ public abstract class FormAuthenticationBase extends AbstractHttpServerMechanism
 
         BareHttpClient.Target targetServer = httpClient.target(hostName, port);
 
-        BareHttpRequest initialRequest = targetServer.buildRequest(defaultUri.getPath()).build();
+        BareHttpRequest initialRequest = targetServer.buildRequest(initialPath).build();
         BareHttpResponse httpResponse = initialRequest.execute();
 
         assertTrue("Response should set JSESSIONID", targetServer.hasCookie("JSESSIONID"));
@@ -186,6 +185,7 @@ public abstract class FormAuthenticationBase extends AbstractHttpServerMechanism
         assertEquals("Expected Redirect", 302, httpResponse.getStatusCode());
         String location = httpResponse.getHeaders().get("Location").get(0);
         URI locationUri = new URI(location);
+        assertTrue("Redirect URI", redirectVerifier.test(locationUri));
 
         assertEquals("Expected same hostName on redirect", hostName, locationUri.getHost());
         assertEquals("Expected same port on redirect", port, locationUri.getPort());
@@ -196,6 +196,14 @@ public abstract class FormAuthenticationBase extends AbstractHttpServerMechanism
         assertEquals("Expected Success", 200, httpResponse.getStatusCode());
         assertEquals("Expected UndertowUser", "ladybird", httpResponse.getHeaders().get("UndertowUser").get(0));
         assertEquals("Expected ElytronUser", "ladybird", httpResponse.getHeaders().get("ElytronUser").get(0));
+    }
+
+    @Test
+    public void testNonEncodedURLBare() throws Exception {
+        URI defaultUri = server.createUri();
+        bareHttpClientRunner(defaultUri.getPath(),
+                (u) ->  (defaultUri.getPath().equals("") && u.getPath().equals("/")) ||
+                        defaultUri.getPath().equals(u.getPath()));
     }
 
     @Override

--- a/undertow-common-test/src/main/java/org/wildfly/elytron/web/undertow/common/FormAuthenticationBase.java
+++ b/undertow-common-test/src/main/java/org/wildfly/elytron/web/undertow/common/FormAuthenticationBase.java
@@ -236,6 +236,23 @@ public abstract class FormAuthenticationBase extends AbstractHttpServerMechanism
         bareHttpClientRunner(path, (p) -> expectedPath.equals(p));
     }
 
+    @Test
+    public void testEncodedPathBare() throws Exception {
+        URI defaultUri = server.createUri();
+        String encodedPath = defaultUri.getPath() + "/file%7B1%7D.txt";
+
+        bareHttpClientRunner(encodedPath, (p) -> encodedPath.equals(p));
+    }
+
+    @Test
+    public void testNonEncodedPathBare() throws Exception {
+        URI defaultUri = server.createUri();
+        String nonEncodedPath = defaultUri.getPath() + "/file{1}.txt";
+        String encodedPath = defaultUri.getPath() + "/file%7B1%7D.txt";
+        // During the round trip to the server it get's encoded.
+        bareHttpClientRunner(nonEncodedPath, (p) -> encodedPath.equals(p));
+    }
+
     @Override
     protected String getMechanismName() {
         return "FORM";

--- a/undertow-common-test/src/main/java/org/wildfly/elytron/web/undertow/common/FormAuthenticationBase.java
+++ b/undertow-common-test/src/main/java/org/wildfly/elytron/web/undertow/common/FormAuthenticationBase.java
@@ -230,7 +230,7 @@ public abstract class FormAuthenticationBase extends AbstractHttpServerMechanism
 
         String path = defaultPath + "?" + nonEncodedQuery;
 
-        String encodedQuery = "project=%7BElytron%20Web%7D";
+        String encodedQuery = "project=%7BElytronWeb%7D";
         String expectedPath = defaultPath + "?" + encodedQuery;
 
         bareHttpClientRunner(path, (p) -> expectedPath.equals(p));

--- a/undertow-common-test/src/main/java/org/wildfly/elytron/web/undertow/common/FormAuthenticationBase.java
+++ b/undertow-common-test/src/main/java/org/wildfly/elytron/web/undertow/common/FormAuthenticationBase.java
@@ -18,6 +18,7 @@
 package org.wildfly.elytron.web.undertow.common;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.wildfly.security.password.interfaces.ClearPassword.ALGORITHM_CLEAR;
 
@@ -156,6 +157,7 @@ public abstract class FormAuthenticationBase extends AbstractHttpServerMechanism
 
         BareHttpRequest initialRequest = targetServer.buildRequest(initialPath).build();
         BareHttpResponse httpResponse = initialRequest.execute();
+        assertNotEquals("Request Rejected", 400, httpResponse.getStatusCode());
 
         assertTrue("Response should set JSESSIONID", targetServer.hasCookie("JSESSIONID"));
         if (httpResponse.getStatusCode() == 302) {
@@ -218,6 +220,20 @@ public abstract class FormAuthenticationBase extends AbstractHttpServerMechanism
         String path = defaultPath + "?" + encodedQuery;
 
         bareHttpClientRunner(path, (p) -> path.equals(p));
+    }
+
+    @Test
+    public void testNonEncodedQueryStringBare() throws Exception {
+        String nonEncodedQuery = "project={ElytronWeb}";
+        URI defaultUri = server.createUri();
+        String defaultPath = defaultUri.getPath().isEmpty() ? "/" : defaultUri.getPath();
+
+        String path = defaultPath + "?" + nonEncodedQuery;
+
+        String encodedQuery = "project=%7BElytron%20Web%7D";
+        String expectedPath = defaultPath + "?" + encodedQuery;
+
+        bareHttpClientRunner(path, (p) -> expectedPath.equals(p));
     }
 
     @Override

--- a/undertow-common-test/src/main/java/org/wildfly/elytron/web/undertow/common/FormAuthenticationBase.java
+++ b/undertow-common-test/src/main/java/org/wildfly/elytron/web/undertow/common/FormAuthenticationBase.java
@@ -144,7 +144,7 @@ public abstract class FormAuthenticationBase extends AbstractHttpServerMechanism
      * @param redirectVerifier
      * @throws Exception
      */
-    public void bareHttpClientRunner(final String initialPath, Predicate<URI> redirectVerifier) throws Exception {
+    public void bareHttpClientRunner(final String initialPath, Predicate<String> redirectVerifier) throws Exception {
         URI defaultUri = server.createUri();
 
         BareHttpClient httpClient = BareHttpClient.builder().build();
@@ -184,13 +184,16 @@ public abstract class FormAuthenticationBase extends AbstractHttpServerMechanism
 
         assertEquals("Expected Redirect", 302, httpResponse.getStatusCode());
         String location = httpResponse.getHeaders().get("Location").get(0);
-        URI locationUri = new URI(location);
-        assertTrue("Redirect URI", redirectVerifier.test(locationUri));
 
+        String redirectPath =  location.substring(location.indexOf('/', 7));
+
+        assertTrue("Redirect URI", redirectVerifier.test(redirectPath));
+
+        URI locationUri = new URI(location);
         assertEquals("Expected same hostName on redirect", hostName, locationUri.getHost());
         assertEquals("Expected same port on redirect", port, locationUri.getPort());
 
-        httpResponse = targetServer.buildRequest(locationUri.getPath())
+        httpResponse = targetServer.buildRequest(redirectPath)
                 .build().execute();
 
         assertEquals("Expected Success", 200, httpResponse.getStatusCode());
@@ -199,11 +202,22 @@ public abstract class FormAuthenticationBase extends AbstractHttpServerMechanism
     }
 
     @Test
-    public void testNonEncodedURLBare() throws Exception {
+    public void testDefaultURLBare() throws Exception {
         URI defaultUri = server.createUri();
-        bareHttpClientRunner(defaultUri.getPath(),
-                (u) ->  (defaultUri.getPath().equals("") && u.getPath().equals("/")) ||
-                        defaultUri.getPath().equals(u.getPath()));
+        String defaultPath = defaultUri.getPath().isEmpty() ? "/" : defaultUri.getPath();
+
+        bareHttpClientRunner(defaultUri.getPath(), (p) ->  defaultPath.equals(p));
+    }
+
+    @Test
+    public void testEncodedQueryStringBare() throws Exception {
+        String encodedQuery = "project=%7BElytron%20Web%7D";
+        URI defaultUri = server.createUri();
+        String defaultPath = defaultUri.getPath().isEmpty() ? "/" : defaultUri.getPath();
+
+        String path = defaultPath + "?" + encodedQuery;
+
+        bareHttpClientRunner(path, (p) -> path.equals(p));
     }
 
     @Override

--- a/undertow-servlet/src/test/java/org/wildfly/elytron/web/undertow/server/servlet/util/UndertowServletServer.java
+++ b/undertow-servlet/src/test/java/org/wildfly/elytron/web/undertow/server/servlet/util/UndertowServletServer.java
@@ -20,6 +20,7 @@ import java.util.function.Supplier;
 
 import javax.net.ssl.SSLContext;
 
+import io.undertow.UndertowOptions;
 import org.wildfly.elytron.web.undertow.common.UndertowServer;
 import org.wildfly.elytron.web.undertow.server.servlet.AuthenticationManager;
 import org.wildfly.security.auth.server.HttpAuthenticationFactory;
@@ -115,6 +116,7 @@ public class UndertowServletServer extends UndertowServer {
         } else {
             undertowBuilder.addHttpListener(port, "localhost");
         }
+        undertowBuilder.setServerOption(UndertowOptions.ALLOW_UNESCAPED_CHARACTERS_IN_URL, true);
 
         undertowServer = undertowBuilder.build();
 

--- a/undertow/src/main/java/org/wildfly/elytron/web/undertow/server/ElytronHttpExchange.java
+++ b/undertow/src/main/java/org/wildfly/elytron/web/undertow/server/ElytronHttpExchange.java
@@ -41,6 +41,7 @@ import java.util.stream.StreamSupport;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
 
+import org.jboss.logging.Logger;
 import org.wildfly.security.auth.server.SecurityIdentity;
 import org.wildfly.security.http.HttpAuthenticationException;
 import org.wildfly.security.http.HttpExchangeSpi;
@@ -74,6 +75,8 @@ import io.undertow.util.HttpString;
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */
 public class ElytronHttpExchange implements HttpExchangeSpi {
+
+    private static final Logger log = Logger.getLogger("org.wildfly.security.http");
 
     private static final AttachmentKey<HttpScope> HTTP_SCOPE_ATTACHMENT_KEY = AttachmentKey.create(HttpScope.class);
     private static final FormParserFactory FORM_PARSER_FACTORY = FormParserFactory.builder().build();
@@ -137,12 +140,16 @@ public class ElytronHttpExchange implements HttpExchangeSpi {
         try {
             Certificate[] peerCertificates = info.getPeerCertificates();
             if (peerCertificates != null || renegotiate==false) return peerCertificates;
-        } catch (SSLPeerUnverifiedException |RenegotiationRequiredException e) {}
+        } catch (SSLPeerUnverifiedException | RenegotiationRequiredException e) {
+            log.trace("Unable to getPeerCertificates", e);
+        }
 
         try {
             info.renegotiate(httpServerExchange, SslClientAuthMode.REQUESTED);
             return httpServerExchange.getConnection().getSslSessionInfo().getPeerCertificates();
-        } catch (IOException | RenegotiationRequiredException e) {}
+        } catch (IOException | RenegotiationRequiredException e) {
+            log.trace("Unable to getPeerCertificates by renegotiating", e);
+        }
 
         return null;
     }
@@ -229,6 +236,7 @@ public class ElytronHttpExchange implements HttpExchangeSpi {
             }
             return new URI(uriBuilder.toString());
         } catch (URISyntaxException e) {
+            log.trace("Unable to construct URI", e);
             return null;
         }
     }
@@ -271,7 +279,9 @@ public class ElytronHttpExchange implements HttpExchangeSpi {
                                                     Collections.unmodifiableList(data.get(s).stream()
                                                             .filter((FormValue v) -> v.isFile() == false)
                                                             .map((FormValue fv) -> fv.getValue()).collect(Collectors.toList()))));
-                        } catch (IOException e) {}
+                        } catch (IOException e) {
+                            log.trace("Unable to parse FORM data", e);
+                        }
                     } else {
                         queryParameters.forEach((name, values) -> parameters.put(name, Collections.unmodifiableList(new ArrayList<String>(values))));
                     }

--- a/undertow/src/main/java/org/wildfly/elytron/web/undertow/server/ElytronHttpExchange.java
+++ b/undertow/src/main/java/org/wildfly/elytron/web/undertow/server/ElytronHttpExchange.java
@@ -18,10 +18,12 @@
 package org.wildfly.elytron.web.undertow.server;
 
 import static org.wildfly.common.Assert.checkNotNullParam;
+import static java.net.URLDecoder.decode;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -205,10 +207,11 @@ public class ElytronHttpExchange implements HttpExchangeSpi {
                 port = httpServerExchange.getHostPort();
                 path = httpServerExchange.getRequestURI();
             }
+
             return new URI(scheme, null, host,
-                    ("http".equals(scheme) && port == 80) || ("https".equals(scheme) && port == 443) ? -1 : port, path,
-                    query == null || "".equals(query) ? null : query, null);
-        } catch (URISyntaxException e) {
+                    ("http".equals(scheme) && port == 80) || ("https".equals(scheme) && port == 443) ? -1 : port, decode(path, "UTF-8"),
+                    query == null || "".equals(query) ? null : decode(query, "UTF-8"), null);
+        } catch (UnsupportedEncodingException | URISyntaxException e) {
             log.trace("Unable to construct URI", e);
             return null;
         }

--- a/undertow/src/main/java/org/wildfly/elytron/web/undertow/server/ElytronHttpExchange.java
+++ b/undertow/src/main/java/org/wildfly/elytron/web/undertow/server/ElytronHttpExchange.java
@@ -205,36 +205,9 @@ public class ElytronHttpExchange implements HttpExchangeSpi {
                 port = httpServerExchange.getHostPort();
                 path = httpServerExchange.getRequestURI();
             }
-            StringBuilder uriBuilder = new StringBuilder();
-            if (scheme != null) {
-                uriBuilder.append(scheme);
-                uriBuilder.append(':');
-            }
-            if (host != null) {
-                uriBuilder.append("//");
-                boolean needBrackets = ((host.indexOf(':') >= 0)
-                        && ! host.startsWith("[")
-                        && ! host.endsWith("]"));
-                if (needBrackets) {
-                    uriBuilder.append('[');
-                }
-                uriBuilder.append(host);
-                if (needBrackets) {
-                    uriBuilder.append(']');
-                }
-            }
-            if (! (("http".equals(scheme) && port == 80) || ("https".equals(scheme) && port == 443))) {
-                uriBuilder.append(':');
-                uriBuilder.append(port);
-            }
-            if (path != null) {
-                uriBuilder.append(path);
-            }
-            if (query != null && ! query.isEmpty()) {
-                uriBuilder.append("?");
-                uriBuilder.append(query);
-            }
-            return new URI(uriBuilder.toString());
+            return new URI(scheme, null, host,
+                    ("http".equals(scheme) && port == 80) || ("https".equals(scheme) && port == 443) ? -1 : port, path,
+                    query == null || "".equals(query) ? null : query, null);
         } catch (URISyntaxException e) {
             log.trace("Unable to construct URI", e);
             return null;

--- a/undertow/src/main/java/org/wildfly/elytron/web/undertow/server/ElytronHttpExchange.java
+++ b/undertow/src/main/java/org/wildfly/elytron/web/undertow/server/ElytronHttpExchange.java
@@ -209,7 +209,8 @@ public class ElytronHttpExchange implements HttpExchangeSpi {
             }
 
             return new URI(scheme, null, host,
-                    ("http".equals(scheme) && port == 80) || ("https".equals(scheme) && port == 443) ? -1 : port, decode(path, "UTF-8"),
+                    ("http".equals(scheme) && port == 80) || ("https".equals(scheme) && port == 443) ? -1 : port,
+                    path != null ? decode(path, "UTF-8") : null,
                     query == null || "".equals(query) ? null : decode(query, "UTF-8"), null);
         } catch (UnsupportedEncodingException | URISyntaxException e) {
             log.trace("Unable to construct URI", e);

--- a/undertow/src/test/java/org/wildfly/elytron/web/undertow/server/UndertowCoreServer.java
+++ b/undertow/src/test/java/org/wildfly/elytron/web/undertow/server/UndertowCoreServer.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 
 import javax.net.ssl.SSLContext;
 
+import io.undertow.UndertowOptions;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 import org.wildfly.elytron.web.undertow.common.UndertowServer;
@@ -80,6 +81,7 @@ public class UndertowCoreServer extends UndertowServer {
         } else {
             builder.addHttpListener(port, "localhost", rootHttpHandler);
         }
+        builder.setServerOption(UndertowOptions.ALLOW_UNESCAPED_CHARACTERS_IN_URL, true);
 
         server = builder.build();
         server.start();


### PR DESCRIPTION
This pull request contains a number of related changes:

The primary issue is tracked under https://issues.redhat.com/browse/ELYWEB-252

Having the option to capture some TRACE messages would have been useful https://issues.redhat.com/browse/ELYWEB-254

A new test utility is added to make it eaiser to send bare HTTP requests that may not conform to the specification so we can test our integration with Undertow's support for these messages https://issues.redhat.com/browse/ELYWEB-255

An original code change in this area was in relation to ensuring we don't re-encode already encoded query strings, additional tests for this were added using https://issues.redhat.com/browse/ELYWEB-253

**This PR depends on https://github.com/wildfly-security/wildfly-elytron/pull/2269 for a clean run.**
