### PR TITLE
[ELYWEB-262] Move back to manually constructing the URL.

### DIFF
--- a/undertow-common-test/src/main/java/org/wildfly/elytron/web/undertow/common/FormAuthenticationBase.java
+++ b/undertow-common-test/src/main/java/org/wildfly/elytron/web/undertow/common/FormAuthenticationBase.java
@@ -223,6 +223,35 @@ public abstract class FormAuthenticationBase extends AbstractHttpServerMechanism
     }
 
     @Test
+    public void testEncodedQueryStringPlusBare() throws Exception {
+        // It is important that %2B does not get mapped to '+' as it can be
+        // misinterpreted as a space.
+        String encodedQuery = "project=%7BElytron%2BWeb%7D";
+        URI defaultUri = server.createUri();
+        String defaultPath = defaultUri.getPath().isEmpty() ? "/" : defaultUri.getPath();
+
+        String path = defaultPath + "?" + encodedQuery;
+
+        bareHttpClientRunner(path, (p) -> path.equals(p));
+    }
+
+    @Test
+    public void testNonEncodedQueryStringPlusBare() throws Exception {
+        String nonEncodedQuery = "project={Elytron+Web}";
+        URI defaultUri = server.createUri();
+        String defaultPath = defaultUri.getPath().isEmpty() ? "/" : defaultUri.getPath();
+
+        String path = defaultPath + "?" + nonEncodedQuery;
+
+        // In this example the caller passed in '+' directly so it is
+        // important that it is preserved.
+        String encodedQuery = "project=%7BElytron+Web%7D";
+        String expectedPath = defaultPath + "?" + encodedQuery;
+
+        bareHttpClientRunner(path, (p) -> expectedPath.equals(p));
+    }
+
+    @Test
     public void testNonEncodedQueryStringBare() throws Exception {
         String nonEncodedQuery = "project={ElytronWeb}";
         URI defaultUri = server.createUri();

--- a/undertow/src/main/java/org/wildfly/elytron/web/undertow/server/ElytronHttpExchange.java
+++ b/undertow/src/main/java/org/wildfly/elytron/web/undertow/server/ElytronHttpExchange.java
@@ -18,12 +18,13 @@
 package org.wildfly.elytron.web.undertow.server;
 
 import static org.wildfly.common.Assert.checkNotNullParam;
-import static java.net.URLDecoder.decode;
+import static org.wildfly.elytron.web.undertow.server.UriPartialEncoder.partialEncode;
 
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -39,19 +40,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
-
-import javax.net.ssl.SSLPeerUnverifiedException;
-import javax.net.ssl.SSLSession;
-
-import org.jboss.logging.Logger;
-import org.wildfly.security.auth.server.SecurityIdentity;
-import org.wildfly.security.http.HttpAuthenticationException;
-import org.wildfly.security.http.HttpExchangeSpi;
-import org.wildfly.security.http.HttpScope;
-import org.wildfly.security.http.HttpScopeNotification;
-import org.wildfly.security.http.HttpServerCookie;
-import org.wildfly.security.http.Scope;
-import org.xnio.SslClientAuthMode;
 
 import io.undertow.security.api.SecurityContext;
 import io.undertow.server.HttpServerExchange;
@@ -70,6 +58,16 @@ import io.undertow.util.AbstractAttachable;
 import io.undertow.util.AttachmentKey;
 import io.undertow.util.Headers;
 import io.undertow.util.HttpString;
+import org.jboss.logging.Logger;
+import org.wildfly.elytron.web.undertow.server.UriPartialEncoder.Component;
+import org.wildfly.security.auth.server.SecurityIdentity;
+import org.wildfly.security.http.HttpAuthenticationException;
+import org.wildfly.security.http.HttpExchangeSpi;
+import org.wildfly.security.http.HttpScope;
+import org.wildfly.security.http.HttpScopeNotification;
+import org.wildfly.security.http.HttpServerCookie;
+import org.wildfly.security.http.Scope;
+import org.xnio.SslClientAuthMode;
 
 /**
  * Implementation of {@link HttpExchangeSpi} to wrap access to the Undertow specific {@link HttpServerExchange}.
@@ -207,12 +205,39 @@ public class ElytronHttpExchange implements HttpExchangeSpi {
                 port = httpServerExchange.getHostPort();
                 path = httpServerExchange.getRequestURI();
             }
+            StringBuilder uriBuilder = new StringBuilder();
+            if (scheme != null) {
+                uriBuilder.append(scheme);
+                uriBuilder.append(':');
+            }
+            if (host != null) {
+                uriBuilder.append("//");
+                boolean needBrackets = ((host.indexOf(':') >= 0)
+                        && ! host.startsWith("[")
+                        && ! host.endsWith("]"));
+                if (needBrackets) {
+                    uriBuilder.append('[');
+                }
+                uriBuilder.append(host);
+                if (needBrackets) {
+                    uriBuilder.append(']');
+                }
+            }
+            if (! (("http".equals(scheme) && port == 80) || ("https".equals(scheme) && port == 443))) {
+                uriBuilder.append(':');
+                uriBuilder.append(port);
+            }
 
-            return new URI(scheme, null, host,
-                    ("http".equals(scheme) && port == 80) || ("https".equals(scheme) && port == 443) ? -1 : port,
-                    path != null ? decode(path, "UTF-8") : null,
-                    query == null || "".equals(query) ? null : decode(query, "UTF-8"), null);
-        } catch (UnsupportedEncodingException | URISyntaxException e) {
+            if (path != null) {
+                uriBuilder.append(partialEncode(path, Component.PATH));
+            }
+
+            if (query != null && ! query.isEmpty()) {
+                uriBuilder.append("?");
+                uriBuilder.append(partialEncode(query, Component.QUERY));
+            }
+            return new URI(uriBuilder.toString());
+        } catch (URISyntaxException e) {
             log.trace("Unable to construct URI", e);
             return null;
         }

--- a/undertow/src/main/java/org/wildfly/elytron/web/undertow/server/UriPartialEncoder.java
+++ b/undertow/src/main/java/org/wildfly/elytron/web/undertow/server/UriPartialEncoder.java
@@ -1,0 +1,185 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2025 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.elytron.web.undertow.server;
+
+import static java.lang.Character.isISOControl;
+import static java.lang.Character.isSpaceChar;
+import static java.lang.Integer.toHexString;
+import static org.wildfly.common.Assert.checkNotNullParam;
+
+/**
+ * Undertow supports being configured to receive path and query components that have not been fully encoded.
+ *
+ * In this case they may have been partially encoded so passing through URI to encode again leads to double
+ * encoding, this utility class is to encode these by taking a second pass and only encoding the characters
+ * that really need it.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+class UriPartialEncoder {
+
+    enum Component {
+
+        PATH(UriPartialEncoder::pathIsAllowed),
+        QUERY(UriPartialEncoder::queryIsAllowed);
+
+        private final CharPredicate predicate;
+
+        Component(CharPredicate predicate) {
+            this.predicate = predicate;
+        }
+
+        boolean isAllowed(final char candidate) {
+            return predicate.test(candidate);
+        }
+
+    };
+
+
+    static String partialEncode(final String value, final Component component) {
+        checkNotNullParam("value", value);
+        checkNotNullParam("component", component);
+
+        StringBuilder sb = new StringBuilder();
+        int length = value.length();
+        for (int i = 0; i < length; i++) {
+            final char c = value.charAt(i);
+
+            if ((c == '%' && i < length - 2 && testPercentEncoded(value.substring(i, i + 3)))
+                || component.isAllowed(c)
+                || !percentEncode(c, sb)) {
+                // It was (first match wins):
+                //  - Part of a correctly percent encoded sequence.
+                //  - Allowed by the component.
+                //  - Not successfully percent encoded.
+                sb.append(c);
+            }
+        }
+
+        return sb.toString();
+    }
+
+    private static boolean percentEncode(final char current, final StringBuilder destination) {
+        if (!canEncode(current)) {
+            return false;
+        }
+
+        destination.append('%');
+        // We know it is not bigger than 0xFF
+        destination.append(toHexString(current).toUpperCase());
+
+        return true;
+    }
+
+    private static boolean canEncode(final char candidate) {
+        return candidate <= 0xFF;
+    }
+
+    private static boolean isUnreserved(final char candidate) {
+        if (  (candidate >= 'A' && candidate <= 'Z')
+            || (candidate >= 'a' && candidate <= 'z')
+            || (candidate >= '0' && candidate <= '9') ) {
+
+            return true;
+        }
+        switch (candidate) {
+            case '_':
+            case '-':
+            case '!':
+            case '.':
+            case '~':
+            case '\'':
+            case '(':
+            case ')':
+            case '*':
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private static boolean isPunct(final char candidate) {
+        switch (candidate) {
+            case ',':
+            case ';':
+            case ':':
+            case '$':
+            case '&':
+            case '+':
+            case '=':
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private static boolean isReserved(final char candidate) {
+        if (isPunct(candidate)) {
+            return true;
+        }
+
+        switch (candidate) {
+            case '?':
+            case '/':
+            case '[':
+            case ']':
+            case '@':
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private static boolean isOther(final char candidate) {
+        return isSpaceChar(candidate) && isISOControl(candidate);
+    }
+
+    private static boolean isPathAllowed(final char candidate) {
+        return candidate == '/' || candidate == '@';
+    }
+
+    private static boolean pathIsAllowed(final char candidate) {
+        return ((isUnreserved(candidate) ||
+                isPunct(candidate) ||
+                isPathAllowed(candidate)) && !isOther(candidate));
+    }
+
+    private static boolean queryIsAllowed(final char candidate) {
+        return (isUnreserved(candidate) || isReserved(candidate)) && !isOther(candidate);
+    }
+
+    private static boolean testPercentEncoded(final String value) {
+        if (value.length() == 3) {
+            return isHex(value.charAt(1)) && isHex(value.charAt(2));
+        }
+
+        // Should not be reachable.
+        return false;
+    }
+
+    private static boolean isHex(final char value) {
+        return (value >= '0' && value <= '9')
+                || (value >= 'A' && value <= 'F')
+                || (value >= 'a' && value <= 'f');
+    }
+
+    interface CharPredicate {
+        boolean test(char c);
+    }
+}


### PR DESCRIPTION
Previous attempts to decode and re-encode the Strings failed so this approach now iterates the Strings to identify where 'additional' encoding may be needed whilst preserving existing percent encoded values.

https://issues.redhat.com/browse/ELYWEB-262

@fjuma / @ivassile This is against the lowest maintenance branch so I could use a review on this one please.

After the previous tags there was a regression in the WildFly testsuite, the one scenario not covered was the handling of the '+' character in URLs, this was further complicated by it having special meaning to also be an alternative way to map a space.

Experimenting with the multi parameter URI constructors I found now way to handle that one cleanly.

This approach is now to handle the encoding ourselves, if and only if it is needed.  The only if means it skips percent encoded characters already present to avoid the double encoding problem.
