### PR TITLE
[ELYWEB-269] Upgrade to JBoss Parent 50

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.jboss</groupId>
         <artifactId>jboss-parent</artifactId>
-        <version>35</version>
+        <version>50</version>
     </parent>
 
     <groupId>org.wildfly.security.elytron-web</groupId>
@@ -66,8 +66,9 @@
         <!-- Checkstyle configuration -->
         <linkXRef>false</linkXRef>
 
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <jdk.min.version>11</jdk.min.version>
+        <maven.compiler.release>8</maven.compiler.release>
+
         <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
 
         <modular.jdk.args/>
@@ -144,20 +145,6 @@
                                 <mainClass>org.wildfly.security._private.Main</mainClass>
                             </manifest>
                         </archive>
-                    </configuration>
-                </plugin>
-
-                <!-- Javadoc -->
-                <plugin>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-                    <configuration>
-                        <doclet>net.gleamynode.apiviz.APIviz</doclet>
-                        <docletArtifact>
-                            <groupId>org.jboss.apiviz</groupId>
-                            <artifactId>apiviz</artifactId>
-                            <version>1.3.2.GA</version>
-                        </docletArtifact>
-                        <excludePackageNames>*._private</excludePackageNames>
                     </configuration>
                 </plugin>
 


### PR DESCRIPTION
Update the build to require Java 11 but still release for Java 8.

Also drop the Javadoc plugin as no longer compatible, will use the configuration from jboss-parent instead.

https://issues.redhat.com/browse/ELYWEB-269